### PR TITLE
Fixed issue with disappearing supporting assets

### DIFF
--- a/app/src/tabs/Supporting Assets/renderer.js
+++ b/app/src/tabs/Supporting Assets/renderer.js
@@ -44,23 +44,17 @@
       }
     }
 
-    const updateSupportingAsset = (id, field, value, asset) => {
-      console.log(id,field,value,asset);
+    const updateSupportingAsset = (id, field, value) => {
       if (field === 'businessAssetRef') {
-
         validate(id, value);
       }
       else {
         if (field === 'supportingAssetName' && value) {
-          addMatrixRow(id, field);
-          if (asset && 'businessAssetRef' in asset) {
-            asset.businessAssetRef.forEach((ref, index) => {
-              addBusinessAsset(id, ref, index);
-            });
-          } else {
-            addBusinessAsset(id, ref, index);
-          }
-
+          if (!document.getElementById(`supporting-asset-business-assets__table-${id}`)) {
+            addMatrixRow(id, value);
+            addBusinessAsset(id, null, 0);
+            validate(id, $(`${matrixTable}-${id} option:selected`).map((i, e) => e.value).get());
+          } 
         }
 
         window.supportingAssets.updateSupportingAsset(id, field, value);
@@ -183,8 +177,6 @@
         // checkbox.value = `${id}`;
         // checkbox.id = `supporting-assets__section-checkbox${id}`;
         // checkbox.name = 'supporting-assets__section-checkbox';
-        // $('#supporting-assets__section-checkboxes').append(checkbox);
-
         if (asset.supportingAssetName) {
           addMatrixRow(id, asset.supportingAssetName);
           asset.businessAssetRef.forEach((ref, index) => {
@@ -193,7 +185,7 @@
         }
 
         const selected = $(`${matrixTable}-${id} option:selected`).map((i, e) => e.value).get();
-        updateSupportingAsset(id, 'businessAssetRef', selected, asset);
+        updateSupportingAsset(id, 'businessAssetRef', selected);
       });
     };
 


### PR DESCRIPTION
Changelog:

In app/src/tabs/Supporting Assets/renderer.js,

- Removed asset parameter in updateSupportingAsset as it is no longer needed since no asset would be selected when the supporting asset is first added to the relationship matrix table

- Removed debug statement

- Updated addMatrixRow second parameter to be value instead of field as value contains the updated name and not field

- Updated conditional statements to check whether id for the current supporting asset exists in matrix table instead of checking for the asset itself and whether it contains businessAssetReference*

*Issue with previous conditional when SA name has been added or updated:

- Current Behavior:

   -  For existing SAs in matrix: bussinessAssetReferences do not need to be added again when SA name is updated but are being added again
   -  For SAs not in matrix: ref and index are not declared, which would throw an exception, breaking the matrix table

- Expected Behavior:
    - For existing SAs in matrix: Nothing to be done within conditional statement
    -  For SAs not in matrix: The supporting asset and a business asset reference should be added to the matrix

    
