### PR TITLE
60 classification configuration does not override imported projects

### DIFF
--- a/app/src/electron/request-handlers.js
+++ b/app/src/electron/request-handlers.js
@@ -67,8 +67,7 @@ const newISRAProject = (win, app) => {
       oldIsraProject = israProject.toJSON();
     };
     getMainWindow().title = browserTitle;
-    const classification = israProject.properties.ISRAmeta.classification
-    win.webContents.send('project:load', israProject.toJSON(), classification);
+    win.webContents.send('project:load', israProject.toJSON());
   } catch (err) {
     console.log(err);
     dialog.showMessageBoxSync(getMainWindow(), { message: 'Failed to create new project' });
@@ -347,8 +346,7 @@ const loadJSONFile = async (win, filePath) => {
   try {
     israProject = new ISRAProject();
     await DataLoad(israProject, filePath);
-    const classification = config.classification
-    win.webContents.send('project:load', israProject.toJSON(), classification);
+    win.webContents.send('project:load', israProject.toJSON());
     jsonFilePath = filePath;
     browserTitle = `ISRA Risk Assessment - ${filePath}`;
     getMainWindow().title = browserTitle;
@@ -367,8 +365,7 @@ const loadJSONFile = async (win, filePath) => {
 const loadXMLFile = (win, filePath) => {
   try {
     israProject = XML2JSON(filePath);
-    const classification = config.classification
-    win.webContents.send('project:load', israProject.toJSON(), classification);
+    win.webContents.send('project:load', israProject.toJSON());
     jsonFilePath = '';
     browserTitle = `ISRA Risk Assessment - ${filePath}`;
     getMainWindow().title = browserTitle;

--- a/app/src/javascript/tabs.js
+++ b/app/src/javascript/tabs.js
@@ -32,9 +32,9 @@ const contents = document.querySelectorAll('.content');
  * loads ISRA Project Data (new project/xml/json)
  * for reference in developer's tool
  */
-window.project.load(async (event, data, classification) => {
+window.project.load(async (event, data) => {
   console.log(await JSON.parse(data));
-  const { projectName } = await JSON.parse(data).ISRAmeta;
+  const { projectName, classification } = await JSON.parse(data).ISRAmeta;
   if(projectName === '') $('footer').text(classification);
   else $('footer').text(classification.substring(0, classification.indexOf('{') + 1) + projectName + classification[classification.length - 1]);
 });

--- a/app/src/tabs/Welcome/renderer.js
+++ b/app/src/tabs/Welcome/renderer.js
@@ -119,8 +119,9 @@
     };
 
     $(document).ready(function () {
-      window.project.load(async (event, data, classification) => {
-        updateWelcomeFields(await JSON.parse(data).ISRAmeta);
+      window.project.load(async (event, data) => {
+        isra= await JSON.parse(data).ISRAmeta
+        updateWelcomeFields(isra);
         classificationLabel = classification;
       });
     });

--- a/lib/src/api/xml-json/populate-class.js
+++ b/lib/src/api/xml-json/populate-class.js
@@ -37,6 +37,7 @@ const RiskAttackPath = require('../../model/classes/Risk/risk-attack-path');
 const RiskMitigation = require('../../model/classes/Risk/risk-mitigation');
 const Vulnerability = require('../../model/classes/Vulnerability/vulnerability');
 const ISRAProject = require('../../model/classes/ISRAProject/isra-project');
+const config = require('../../config')
 
 /** populating each ISRA JSON data to the corresponding classes
          * @function populateClass
@@ -47,8 +48,15 @@ const ISRAProject = require('../../model/classes/ISRAProject/isra-project');
 // Object.assign(target_class, source)
 const populateClass = (data, israProject) => {
   const {
-    ISRAtracking, projectName, projectOrganization, projectVersion, classification, iteration, latestBusinessAssetId, latestSupportingAssetId, latestRiskId, latestVulnerabilityId
+    ISRAtracking, projectName, projectOrganization, projectVersion, iteration, latestBusinessAssetId, latestSupportingAssetId, latestRiskId, latestVulnerabilityId
   } = data.ISRAmeta;
+
+  var { classification } = data.ISRAmeta;
+
+  // Update classification
+  if (classification != config.classification) {
+    classification = config.classification
+  }
 
   // populate ISRAMetaTracking
   ISRAtracking.forEach((tracking) => {


### PR DESCRIPTION
Changelog
-
### Issue #62 and #60
Files Changed: 

      1. app/src/electron/request-handlers.js
      2. app/src/javascript/tabs.js
      3. app/src/tabs/Welcome/renderer.js
      4. lib/src/api/xml-json/populate-class.js

Changes:

       1. Updated functions that use classification to not use classification argument for webContents.send
       2. Removed classification argument from project.load and retrieve classification from JSON data instead
       3. 

    
