### PR TITLE
Fixed UI issue that is caused by value assignment of access resources…

### DIFF
--- a/app/src/tabs/Risks/renderer.js
+++ b/app/src/tabs/Risks/renderer.js
@@ -373,13 +373,13 @@
         occurrence
       } = riskLikelihood;
 
-      $('select[id="risk__skillLevel"]').val(!skillLevel ? 'null' : skillLevel);
-      $('select[id="risk__reward"]').val(!reward ? 'null' : reward);
+      $('select[id="risk__skillLevel"]').val(skillLevel == null? 'null' : skillLevel);
+      $('select[id="risk__reward"]').val(reward == null? 'null' : reward);
       $('select[id="risk__accessResources"]').val(accessResources == null? 'null' : accessResources);
-      $('select[id="risk__size"]').val(!size ? 'null' : size);
-      $('select[id="risk__intrusionDetection"]').val(!intrusionDetection ? 'null' : intrusionDetection);
-      $('select[id="risk__occurrence"]').val(!occurrence ? 'null' : occurrence);
-      $('select[id="risk__likelihood"]').val(!riskLikelihood.riskLikelihood ? 'null' : riskLikelihood.riskLikelihood);
+      $('select[id="risk__size"]').val(size == null? 'null' : size);
+      $('select[id="risk__intrusionDetection"]').val(intrusionDetection == null? 'null' : intrusionDetection);
+      $('select[id="risk__occurrence"]').val(occurrence == null? 'null' : occurrence);
+      $('select[id="risk__likelihood"]').val(riskLikelihood.riskLikelihood == null? 'null' : riskLikelihood.riskLikelihood);
     };
 
     const addRichTextArea = (selector, desc, width, riskMitigationId) => {


### PR DESCRIPTION
Changelog

In app/src/tabs/Risks/renderer.js, updated null check to directly check for a null value instead of using not operator as this would cause 0 which is mapped to Full resources to become null, making Select to be displatyed instead