### PR TITLE
Rollback version tinymce to 6.8.3 for license changes

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -12,7 +12,7 @@
                 "chart.js": "^4.3.2",
                 "jquery": "^3.6.1",
                 "tabulator-tables": "^5.3.4",
-                "tinymce": "^7.0.0"
+                "tinymce": "^6.8.3"
             },
             "devDependencies": {
                 "electron": "^22.3.25",
@@ -2401,12 +2401,6 @@
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "dev": true
         },
-        "node_modules/ip": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
-            "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
-            "dev": true
-        },
         "node_modules/is-ci": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
@@ -3489,9 +3483,9 @@
             }
         },
         "node_modules/tinymce": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-7.0.0.tgz",
-            "integrity": "sha512-ggXLfTRrUALAcjeJSRrZcJDOl6MgC2tPXe/zNOEkQXvTDgcKqFypPRoPpfpK5wejexjyaI/7dwETOntJ5MPBFg=="
+            "version": "6.8.3",
+            "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-6.8.3.tgz",
+            "integrity": "sha512-3fCHKAeqT+xNwBVESf6iDbDV0VNwZNmfrkx9c/6Gz5iB8piMfaO6s7FvoiTrj1hf1gVbfyLTnz1DooI6DhgINQ=="
         },
         "node_modules/tmp": {
             "version": "0.2.3",

--- a/app/package.json
+++ b/app/package.json
@@ -16,14 +16,14 @@
     "build": {
         "fileAssociations": [
             {
-              "ext": "sra",
-              "description": "ISRA File",
-              "role": "Editor"
+                "ext": "sra",
+                "description": "ISRA File",
+                "role": "Editor"
             },
             {
-              "ext": "xml",
-              "description": "XML File",
-              "role": "Editor"
+                "ext": "xml",
+                "description": "XML File",
+                "role": "Editor"
             }
         ],
         "nsis": {
@@ -66,7 +66,6 @@
                 {
                     "target": "nsis",
                     "arch": "x64"
-                    
                 }
             ]
         },
@@ -86,7 +85,7 @@
         "chart.js": "^4.3.2",
         "jquery": "^3.6.1",
         "tabulator-tables": "^5.3.4",
-        "tinymce": "^7.0.0"
+        "tinymce": "^6.8.3"
     },
     "devDependencies": {
         "electron": "^22.3.25",


### PR DESCRIPTION
Rollback tinymce version from 7.0.0 to 6.8.3 to avoid license changes
A moderate severity vulnerability is displayed but is linked to cross-site Scripting, this app is not a website, the vulnerability may be accepted