### PR TITLE
fix the validation of supporting asset attributes when changing business asset or name

### DIFF
--- a/app/src/tabs/Supporting Assets/renderer.js
+++ b/app/src/tabs/Supporting Assets/renderer.js
@@ -27,9 +27,12 @@
 (async () => {
   var fetchedData
 
+    const countInArray = (array,ref) =>{
+      return array.reduce((n, x) => n + (x === ref), 0);
+    }
     // Check if the businessAsset is valid
     const checkBusinessAssetRef = (ref) =>{
-      if (ref === null) return false
+      if (ref === null || ref == "null") return false
       let foundBusinessAsset = fetchedData.BusinessAsset.find(obj => obj.businessAssetId == ref);
       return foundBusinessAsset && foundBusinessAsset.businessAssetName !== '' ? true : false
     };
@@ -70,13 +73,11 @@
 
     const validate = (id, field, value) =>{
       let sa = findSupportingAsset(id)
-      if ((field === 'businessAssetRef'
-          && (value.length === 0 && !$(`${matrixTable}-${id} select`).length
-            || value.length !== new Set(value).size
-            || value.includes('null')
-            || !checkBusinessAssetRefArray(value)
-            || (sa && sa.supportingAssetName =='')))
-        || (field === 'supportingAssetName' && (!value || value=='' || (sa && !checkBusinessAssetRefArray(sa.businessAssetRef))))) {
+      if (!sa) return
+      let saBARef = field === 'businessAssetRef'? value : sa.businessAssetRef
+      let saName = field === 'supportingAssetName'? value : sa.supportingAssetName
+
+      if (!checkBusinessAssetRefArray(saBARef) || (saBARef.length === 0 && !$(`${matrixTable}-${id} select`).length) || saBARef.length !== new Set(saBARef).size || !saName || saName==''){
         $(`${matrixTable}-${id} td.matrix-sa-id`).css('color', 'red');
         $(`${matrixTable}-${id} td.matrix-sa-id`).css('font-weight', 'bold');
         $(`${matrixTable}-${id} td.matrix-sa-name`).css('color', 'red');
@@ -87,6 +88,25 @@
         $(`${matrixTable}-${id} td.matrix-sa-name`).css('color', 'black');
         $(`${matrixTable}-${id} td.matrix-sa-name`).css('font-weight', 'normal');
       }
+    }
+
+    const updateSelectDesign = (id) => {
+      // Retrieve the current set of selected business asset
+      let currentOptions = []
+      $(`${matrixTable}-${id} td.matrix-sa-ba div select`).map((key,item) => (
+        currentOptions.push(item.value)
+      ))
+    
+      // Retrieve the duplicated selected business asset
+      let mappingDuplicate = {}
+      $(`${matrixTable}-${id} td.matrix-sa-ba div select`).map((key,item) => (
+        mappingDuplicate[item.value] = countInArray(currentOptions,item.value)
+      ))
+
+      // Update the design of the invalid selects
+      $(`${matrixTable}-${id} td.matrix-sa-ba div select`).map((key,item) => (
+        !item.value || item.value == "null" ||  mappingDuplicate[item.value] > 1 ?  item.setAttribute('style', `border-color : red; border-width: 3px`): item.setAttribute('style', `border-color : black; border-width: 1px`)
+      ))
     }
 
     const supportingAssetsTable = new Tabulator('#supporting-assets__section-table', result[1]);
@@ -157,15 +177,16 @@
       };
       newSelect.value = ref;
       prevOption();
-      newSelect.setAttribute('style',`border-color:${!checkBusinessAssetRef(newSelect.value) || (sa && sa.businessAssetRef.includes(newSelect.value))? 'red' : 'black'};border-width: ${!checkBusinessAssetRef(newSelect.value) || (sa && sa.businessAssetRef.includes(newSelect.value)) ? 3 : 1}px`);
+      newSelect.setAttribute('style',!checkBusinessAssetRef(ref) || (sa && countInArray(sa.businessAssetRef,ref) > 1 ) ? `border-color : red; border-width: 3px`: `border-color : black; border-width: 1px`)
 
       // change in selected option due to user input
       $(newSelect).on('change', (e) => {
         let prevOptions=sa ? sa.businessAssetRef : []
         window.supportingAssets.updateBusinessAssetRef(id, e.target.value === 'null' ? null : e.target.value, $(e.target).attr('data-index'));
         const selected = $(`${matrixTable}-${id} option:selected`).map((i, e) => e.value).get();
-        updateSupportingAsset(id, 'businessAssetRef', selected);      
-        newSelect.setAttribute('style',`border-color:${!checkBusinessAssetRef(e.target.value) || prevOptions.includes(e.target.value)? 'red' : 'black'};border-width: ${!checkBusinessAssetRef(e.target.value) || prevOptions.includes(e.target.value)? 3 : 1}px`);
+        updateSupportingAsset(id, 'businessAssetRef', selected);
+        newSelect.setAttribute('style',!checkBusinessAssetRef(e.target.value) || (countInArray(prevOptions,e.target.value) > 0) ? `border-color : red; border-width: 3px`: `border-color : black; border-width: 1px`)
+        updateSelectDesign(id)
       });
 
       // possible change in selected option due to add/delete BusinessAssets
@@ -228,6 +249,8 @@
         const selected = $(`${matrixTable}-${id} option:selected`).map((i, e) => !e.value ? null : e.value).get();
         validate(id, 'businessAssetRef', selected);
         updateSupportingAsset(id, 'businessAssetRef', selected)
+                
+        updateSelectDesign(id)
       });
     };
 

--- a/app/src/tabs/Supporting Assets/renderer.js
+++ b/app/src/tabs/Supporting Assets/renderer.js
@@ -72,10 +72,9 @@
     let selectOptions = {};
 
     const validate = (id, field, value) =>{
-      let sa = findSupportingAsset(id)
-      if (!sa) return
-      let saBARef = field === 'businessAssetRef'? value : sa.businessAssetRef
-      let saName = field === 'supportingAssetName'? value : sa.supportingAssetName
+      let sa = supportingAssetsTable.getRow(id).getData()
+      let saBARef = field === 'businessAssetRef'? value : sa?  sa.businessAssetRef : null
+      let saName = field === 'supportingAssetName'? value : sa ? sa.supportingAssetName : null
 
       if (!checkBusinessAssetRefArray(saBARef) || (saBARef.length === 0 && !$(`${matrixTable}-${id} select`).length) || saBARef.length !== new Set(saBARef).size || !saName || saName==''){
         $(`${matrixTable}-${id} td.matrix-sa-id`).css('color', 'red');


### PR DESCRIPTION
Bugged behaviors:
1) When the business asset was doubled, no error was display on the input.
![image](https://github.com/ThalesGroup/security-risk-assessment-tool/assets/164328304/2c55b39a-8029-4a61-b6f6-b5c0794a52ed)

2) It was also possible to see the Id and Supporting Asset text to black instead of red when there are still issues
![image](https://github.com/ThalesGroup/security-risk-assessment-tool/assets/164328304/d0b5fc96-14e5-4168-9864-dd013877af39)

Duplicate Steps for 1):
Select 2 times the same Business Asset for the same Supporting Asset

Duplicate Steps for 2):
Add a new select input
See the Name (in List of Supporting Assets), Id & Supporting Asset (in Supporting Asset / Business Assets) turn red
Delete the Name (in List of Supporting Assets)
Set the Name (in List of Supporting Assets)
See the Name (in List of Supporting Assets) turn red but not Id & Supporting Asset (in Supporting Asset / Business Assets)

Post fix behavior:
![image](https://github.com/ThalesGroup/security-risk-assessment-tool/assets/164328304/2b31c060-9098-4b8b-ab9f-40ad1ccdc915)
