### PR TITLE
Fix disabled buttons when opening file without the stored risk id from risk panel

### DIFF
--- a/app/src/tabs/Risks/renderer.js
+++ b/app/src/tabs/Risks/renderer.js
@@ -860,7 +860,7 @@ function enableInteract(){
 
     // render selected row data on page by riskId
     const addSelectedRowData = async (id) =>{
-      if (!addSelectedRowDataExecuting){
+      if (!addSelectedRowDataExecuting && risksData.find((risk) => risk.riskId == id)){
         addSelectedRowDataExecuting = true;
         const {
           riskId,
@@ -1044,7 +1044,8 @@ function enableInteract(){
       disableRiskSelection()
 
       // Select the latest risk selected (stored in the browser's volatile storage) (default: first risk of the table)
-      const selectedRisk = sessionStorage.getItem("currentRisk") ? sessionStorage.getItem("currentRisk") : fetchedData[0].riskId
+      const previousRiskId = sessionStorage.getItem("currentRisk")
+      const selectedRisk = previousRiskId && fetchedData.find((risk) => risk.riskId == previousRiskId) ? previousRiskId : fetchedData[0].riskId
       risksTable.selectRow(selectedRisk);
       await addSelectedRowData(selectedRisk);
       /* fetchedData.forEach((risk, i) => {

--- a/app/src/tabs/Vulnerabilities/renderer.js
+++ b/app/src/tabs/Vulnerabilities/renderer.js
@@ -184,7 +184,8 @@
         $('#vulnerabilties__table__checkboxes').empty();
         vulnerabilitiesTable.addData(vulnerabilities);
         // Select the latest vulerability selected (stored in the browser's volatile storage) (default: first vulerability of the table)
-        const selectedVulnerability = sessionStorage.getItem("currentVulnerability") ? sessionStorage.getItem("currentVulnerability") : vulnerabilities[0].vulnerabilityId
+        const previousVulId = sessionStorage.getItem("currentVulnerability")
+        const selectedVulnerability = previousVulId && vulnerabilities.find((v) => v.vulnerabilityId == previousVulId)? previousVulId : vulnerabilities[0].vulnerabilityId
         vulnerabilitiesTable.selectRow(selectedVulnerability);
         addSelectedVulnerabilityRowData(selectedVulnerability);
 


### PR DESCRIPTION
Bug:
![image](https://github.com/ThalesGroup/security-risk-assessment-tool/assets/164328304/00c9496a-4849-4bc0-96b1-dd75e0232076)

Duplicate steps:
Go in Risk panel
Select any risk
Open a file that does not contain the previous selected id