### PR TITLE
Split conditions

### DIFF
--- a/app/src/electron/request-handlers.js
+++ b/app/src/electron/request-handlers.js
@@ -286,8 +286,13 @@ const validateClasses = () => {
       if (ref === null) return 
       let foundSupportingAsset = SupportingAsset.find(obj => obj.supportingAssetId == ref);
 
-      if (foundSupportingAsset.businessAssetRef.length == 0 || foundSupportingAsset.businessAssetRef.length !== new Set(foundSupportingAsset.businessAssetRef).size || !checkBusinessAssetRefArray(foundSupportingAsset.businessAssetRef) || foundSupportingAsset.supportingAssetName == ''){
-          return false
+      if (
+        foundSupportingAsset.businessAssetRef.length == 0 ||
+        foundSupportingAsset.businessAssetRef.length !== new Set(foundSupportingAsset.businessAssetRef).size ||
+        !checkBusinessAssetRefArray(foundSupportingAsset.businessAssetRef) ||
+        foundSupportingAsset.supportingAssetName == ''
+      ){
+        return false
       }
       return true
   };
@@ -305,7 +310,13 @@ const validateClasses = () => {
     const checkVulnerabilityRef = (ref,supportingAssetRef) =>{
       if (ref === null) return false
       found = Vulnerability.find(obj => obj.vulnerabilityId === ref.vulnerabilityId);
-      if (!found || !found.supportingAssetRef.includes(supportingAssetRef)||!checkSupportingAssetRefArray(found.supportingAssetRef) || found.vulnerabilityName === '' || found.vulnerabilityDescription === '') return false
+      if (
+        !found ||
+        !found.supportingAssetRef.includes(supportingAssetRef) ||
+        !checkSupportingAssetRefArray(found.supportingAssetRef) || 
+        found.vulnerabilityName === '' || 
+        found.vulnerabilityDescription === ''
+      ) return false
       return true
     };
 
@@ -325,7 +336,13 @@ const validateClasses = () => {
 
   const validateRiskDescription = (risk) => {
     const { threatAgent, threatVerb, businessAssetRef, supportingAssetRef, motivation } = risk;
-    if (threatAgent === '' || threatVerb === '' || ! checkBusinessAssetRef(businessAssetRef) || ! checkSupportingAssetRef(supportingAssetRef) || motivation === ''){
+    if (
+      threatAgent === '' || 
+      threatVerb === '' || 
+      ! checkBusinessAssetRef(businessAssetRef) || 
+      ! checkSupportingAssetRef(supportingAssetRef) || 
+      motivation === ''
+    ){
       return false;
     } else return true;
   };

--- a/app/src/tabs/Report/renderer.js
+++ b/app/src/tabs/Report/renderer.js
@@ -174,8 +174,14 @@
           if (ref === null) return 
           let foundSupportingAsset = existSupportingAsset(ref)
         
-          if (foundSupportingAsset == null || foundSupportingAsset.businessAssetRef.length == 0 || foundSupportingAsset.businessAssetRef.length !== new Set(foundSupportingAsset.businessAssetRef).size || !checkBusinessAssetRefArray(foundSupportingAsset.businessAssetRef) || foundSupportingAsset.supportingAssetName == ''){
-              return false
+          if (
+            foundSupportingAsset == null ||
+            foundSupportingAsset.businessAssetRef.length == 0 || 
+            foundSupportingAsset.businessAssetRef.length !== new Set(foundSupportingAsset.businessAssetRef).size || 
+            !checkBusinessAssetRefArray(foundSupportingAsset.businessAssetRef) || 
+            foundSupportingAsset.supportingAssetName == ''
+          ){
+            return false
           }
           return true
         };
@@ -194,7 +200,13 @@
         const checkVulnerabilityRef = (ref,supportingAssetRef) =>{
           if (ref === null) return false
           found = fetchedData.Vulnerability.find(obj => obj.vulnerabilityId === ref);
-          if (!found || !found.supportingAssetRef.includes(supportingAssetRef)||!checkSupportingAssetRefArray(found.supportingAssetRef) || found.vulnerabilityName === '' || found.vulnerabilityDescription === '') return false
+          if (
+            !found ||
+            !found.supportingAssetRef.includes(supportingAssetRef) ||
+            !checkSupportingAssetRefArray(found.supportingAssetRef) || 
+            found.vulnerabilityName === '' || 
+            found.vulnerabilityDescription === ''
+          ) return false
           return true
         };
       
@@ -214,7 +226,14 @@
       
         const validateRiskName = (risk) => {
           const { threatAgent, threatVerb, businessAssetRef, supportingAssetRef, motivation,riskAttackPaths } = risk;
-          if (threatAgent === '' || threatVerb === '' || ! checkBusinessAssetRef(businessAssetRef) || ! checkSupportingAssetRef(supportingAssetRef) || ! checkRiskAttackPaths(riskAttackPaths,supportingAssetRef) || motivation === ''){
+          if (
+            threatAgent === '' || 
+            threatVerb === '' || 
+            ! checkBusinessAssetRef(businessAssetRef) || 
+            ! checkSupportingAssetRef(supportingAssetRef) || 
+            ! checkRiskAttackPaths(riskAttackPaths,supportingAssetRef) || 
+            motivation === ''
+          ){
             return '#FF0000';
           } else return '#000000';
         };

--- a/app/src/tabs/Risks/renderer.js
+++ b/app/src/tabs/Risks/renderer.js
@@ -216,8 +216,14 @@ function enableInteract(){
       if (ref === null) return 
       let foundSupportingAsset = existSupportingAsset(ref)
 
-      if (foundSupportingAsset == null || foundSupportingAsset.businessAssetRef.length == 0 || foundSupportingAsset.businessAssetRef.length !== new Set(foundSupportingAsset.businessAssetRef).size || !checkBusinessAssetRefArray(foundSupportingAsset.businessAssetRef) || foundSupportingAsset.supportingAssetName == ''){
-          return false
+      if (
+        foundSupportingAsset == null || 
+        foundSupportingAsset.businessAssetRef.length == 0 || 
+        foundSupportingAsset.businessAssetRef.length !== new Set(foundSupportingAsset.businessAssetRef).size || 
+        !checkBusinessAssetRefArray(foundSupportingAsset.businessAssetRef) || 
+        foundSupportingAsset.supportingAssetName == ''
+      ){
+        return false
       }
       return true
     };
@@ -236,7 +242,13 @@ function enableInteract(){
     const checkVulnerabilityRef = (ref,supportingAssetRef) =>{
       if (ref === null) return false
       found = vulnerabilities.find(obj => obj.vulnerabilityId === ref);
-      if (!found || !found.supportingAssetRef.includes(supportingAssetRef)||!checkSupportingAssetRefArray(found.supportingAssetRef) || found.vulnerabilityName === '' || found.vulnerabilityDescription === '') return false
+      if (
+        !found ||
+        !found.supportingAssetRef.includes(supportingAssetRef) ||
+        !checkSupportingAssetRefArray(found.supportingAssetRef) || 
+        found.vulnerabilityName === '' || 
+        found.vulnerabilityDescription === ''
+      ) return false
       return true
     };
 
@@ -256,7 +268,14 @@ function enableInteract(){
 
     const validateRiskName = (risk) => {
       const { threatAgent, threatVerb, businessAssetRef, supportingAssetRef, motivation,riskAttackPaths } = risk;
-      if (threatAgent === '' || threatVerb === '' || ! checkBusinessAssetRef(businessAssetRef) || ! checkSupportingAssetRef(supportingAssetRef) || ! checkRiskAttackPaths(riskAttackPaths,supportingAssetRef) || motivation === ''){
+      if (
+        threatAgent === '' || 
+        threatVerb === '' || 
+        ! checkBusinessAssetRef(businessAssetRef) || 
+        ! checkSupportingAssetRef(supportingAssetRef) || 
+        ! checkRiskAttackPaths(riskAttackPaths,supportingAssetRef) || 
+        motivation === ''
+      ){
         return '#FF0000';
       } else return '#000000';
     };

--- a/app/src/tabs/Supporting Assets/renderer.js
+++ b/app/src/tabs/Supporting Assets/renderer.js
@@ -52,7 +52,12 @@
     };
 
     const validateSAName = (sa) => {
-      if (sa.businessAssetRef.length == 0 || sa.businessAssetRef.length !== new Set(sa.businessAssetRef).size || !checkBusinessAssetRefArray(sa.businessAssetRef) || sa.supportingAssetName == ''){
+      if (
+        sa.businessAssetRef.length == 0 || 
+        sa.businessAssetRef.length !== new Set(sa.businessAssetRef).size || 
+        !checkBusinessAssetRefArray(sa.businessAssetRef) || 
+        sa.supportingAssetName == ''
+      ){
         return '#FF0000';
       } else return '#000000';
     };
@@ -104,7 +109,10 @@
 
       // Update the design of the invalid selects
       $(`${matrixTable}-${id} td.matrix-sa-ba div select`).map((key,item) => (
-        !item.value || item.value == "null" ||  mappingDuplicate[item.value] > 1 ?  item.setAttribute('style', `border-color : red; border-width: 3px`): item.setAttribute('style', `border-color : black; border-width: 1px`)
+        !item.value || 
+        item.value == "null" || 
+        mappingDuplicate[item.value] > 1 ? 
+        item.setAttribute('style', `border-color : red; border-width: 3px`): item.setAttribute('style', `border-color : black; border-width: 1px`)
       ))
     }
 

--- a/app/src/tabs/Vulnerabilities/renderer.js
+++ b/app/src/tabs/Vulnerabilities/renderer.js
@@ -56,7 +56,13 @@
         const supportingAssetRef = rowData.supportingAssetRef
         const vulnerabilityDescription = rowData.vulnerabilityDescription
         const vulnerabilityName = rowData.vulnerabilityName
-        if (supportingAssetsData.length === 0 || supportingAssetRef.length === 0 || !checkSupportingAssetRefArray(supportingAssetRef) || vulnerabilityDescription === '' || vulnerabilityName === '')  {
+        if (
+            supportingAssetsData.length === 0 || 
+            supportingAssetRef.length === 0 || 
+            !checkSupportingAssetRefArray(supportingAssetRef) || 
+            vulnerabilityDescription === '' || 
+            vulnerabilityName === ''
+        ) {
             cell.getElement().style.color = '#FF0000';
         }
         else  {
@@ -148,7 +154,10 @@
         if (ref === null) return 
         let foundSupportingAsset = fetchedData.SupportingAsset.find(obj => obj.supportingAssetId == ref);
 
-        if (foundSupportingAsset.businessAssetRef.length == 0 || foundSupportingAsset.businessAssetRef.length !== new Set(foundSupportingAsset.businessAssetRef).size || !checkBusinessAssetRefArray(foundSupportingAsset.businessAssetRef) || foundSupportingAsset.supportingAssetName == ''){
+        if (foundSupportingAsset.businessAssetRef.length == 0 || 
+            foundSupportingAsset.businessAssetRef.length !== new Set(foundSupportingAsset.businessAssetRef).size || 
+            !checkBusinessAssetRefArray(foundSupportingAsset.businessAssetRef) || 
+            foundSupportingAsset.supportingAssetName == ''){
             return false
         }
         return true


### PR DESCRIPTION
The conditions that were to difficult to read have been split in multiple lines

Example : 
![image](https://github.com/ThalesGroup/security-risk-assessment-tool/assets/164328304/42417d72-6bc1-4502-ac24-d764304b76aa)

To 

![image](https://github.com/ThalesGroup/security-risk-assessment-tool/assets/164328304/d6171df9-576d-44c7-8612-94c736c21d8e)
