### PR TITLE
Fixed vulnerability page to display Critical, Refactor: Centralize severity colour palette and unify usage across all tabs

### DIFF
--- a/app/src/global styles/global-styles.css
+++ b/app/src/global styles/global-styles.css
@@ -1,14 +1,14 @@
 /*----------------------------------------------------------------------------
 *
-*     Copyright © 2022 THALES. All Rights Reserved.
- *
+*     Copyright © 2025 THALES. All Rights Reserved.
+*
 * -----------------------------------------------------------------------------
 * THALES MAKES NO REPRESENTATIONS OR WARRANTIES ABOUT THE SUITABILITY OF
 * THE SOFTWARE, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
- * TO THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
- * PARTICULAR PURPOSE, OR NON-INFRINGEMENT. THALES SHALL NOT BE
- * LIABLE FOR ANY DAMAGES SUFFERED BY LICENSEE AS A RESULT OF USING,
- * MODIFYING OR DISTRIBUTING THIS SOFTWARE OR ITS DERIVATIVES.
+* TO THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+* PARTICULAR PURPOSE, OR NON-INFRINGEMENT. THALES SHALL NOT BE
+* LIABLE FOR ANY DAMAGES SUFFERED BY LICENSEE AS A RESULT OF USING,
+* MODIFYING OR DISTRIBUTING THIS SOFTWARE OR ITS DERIVATIVES.
 *
 * THIS SOFTWARE IS NOT DESIGNED OR INTENDED FOR USE OR RESALE AS ON-LINE
 * CONTROL EQUIPMENT IN HAZARDOUS ENVIRONMENTS REQUIRING FAIL-SAFE
@@ -21,6 +21,21 @@
 * HIGH RISK ACTIVITIES.
 * -----------------------------------------------------------------------------
 */
+:root {
+    --severity-low: #000000;
+    --severity-low-contrast: #ffffff;
+    --severuty-low-background: #38E54D;
+    --severity-medium: #FAAB24;
+    --severity-medium-contrast: #000000;
+    --severity-medium-background: #ffa500;
+    --severity-high: #E35623;
+    --severity-high-contrast: #ffffff;
+    --severity-high-background: #ff0000;
+    --severity-critical: #D32A26;
+    --severity-critical-contrast: #ffffff;
+    --severity-very-high-background: #9f204b;
+}
+
 html {
     height: 100%;
 }
@@ -30,7 +45,6 @@ body {
     margin:0;
 }
 /*tabs*/
-
 .wrapper {
     width: 100%;
     height: 100%;
@@ -92,14 +106,12 @@ button.tab-button:hover{
     padding: 10px 20px;
     background-color: #dedede;
 } */
-
 .content .active {
     display: block;
     padding: 10px 20px;
 }
 
 /*tabs*/
-
 footer{
     text-align: center;
     margin-top: 10px;
@@ -218,7 +230,6 @@ select option {
 }
 
 /*tooltip*/
-
 .tabulator-tooltip {
     font-family: Arial, Helvetica, sans-serif;
     color: #4f4f4f;
@@ -264,7 +275,6 @@ select option {
     height:12px;
     overflow:hidden;
 } */
-
 /* .tooltip .top i::after {
     content:'';
     position:absolute;
@@ -275,9 +285,7 @@ select option {
     background-color:#FFFFFF;
     border:1px solid transparent;box-shadow:0 1px 8px transparent;
 } */
-
 /*tooltip*/
-
 article, section{
     padding: 10px;
     margin-bottom: 10px;

--- a/app/src/tabs/Import/renderer.js
+++ b/app/src/tabs/Import/renderer.js
@@ -1,14 +1,14 @@
 /*----------------------------------------------------------------------------
 *
-*     Copyright © 2022 THALES. All Rights Reserved.
+*     Copyright © 2025 THALES. All Rights Reserved.
  *
 * -----------------------------------------------------------------------------
 * THALES MAKES NO REPRESENTATIONS OR WARRANTIES ABOUT THE SUITABILITY OF
 * THE SOFTWARE, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
- * TO THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
- * PARTICULAR PURPOSE, OR NON-INFRINGEMENT. THALES SHALL NOT BE
- * LIABLE FOR ANY DAMAGES SUFFERED BY LICENSEE AS A RESULT OF USING,
- * MODIFYING OR DISTRIBUTING THIS SOFTWARE OR ITS DERIVATIVES.
+* TO THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+* PARTICULAR PURPOSE, OR NON-INFRINGEMENT. THALES SHALL NOT BE
+* LIABLE FOR ANY DAMAGES SUFFERED BY LICENSEE AS A RESULT OF USING,
+* MODIFYING OR DISTRIBUTING THIS SOFTWARE OR ITS DERIVATIVES.
 *
 * THIS SOFTWARE IS NOT DESIGNED OR INTENDED FOR USE OR RESALE AS ON-LINE
 * CONTROL EQUIPMENT IN HAZARDOUS ENVIRONMENTS REQUIRING FAIL-SAFE
@@ -24,6 +24,21 @@
 /* global $ tinymce Tabulator */
 
 //const { ipcRenderer } = require('electron').ipcRenderer;
+
+const { SEVERITY_COLORS = {} } = window.COLOR_CONSTANTS || {};
+const getSeverityColor = (level) => {
+  switch (level) {
+    case 'Critical':
+      return SEVERITY_COLORS.CRITICAL || '#D32A26';
+    case 'High':
+      return SEVERITY_COLORS.HIGH || '#E35623';
+    case 'Medium':
+      return SEVERITY_COLORS.MEDIUM || '#FAAB24';
+    default:
+      return SEVERITY_COLORS.LOW || '#000000';
+  }
+};
+
 
 (async () => {
   try {
@@ -112,10 +127,7 @@
 
 risksTableConfig.columns[levelIndex].formatter = (cell) => {
   const residualRiskLevel = cell.getValue()
-  if (residualRiskLevel === 'Critical') cell.getElement().style.color = '#FF0000';
-  else if (residualRiskLevel === 'High') cell.getElement().style.color = '#E73927';
-  else if (residualRiskLevel === 'Medium') cell.getElement().style.color = '#FFA500';
-  else cell.getElement().style.color = '#000000';
+  cell.getElement().style.color = getSeverityColor(residualRiskLevel);
 
   
   return residualRiskLevel;
@@ -151,9 +163,7 @@ risksTableConfig.columns[levelIndex].formatter = (cell) => {
 
 vulnerabilityTableConfig.columns[levelIndex].formatter = (cell) => {
   const overallLevel = cell.getValue()
-  if (overallLevel === 'High') cell.getElement().style.color = '#FF0000';
-  else if (overallLevel === 'Medium') cell.getElement().style.color = '#FFA500';
-  else cell.getElement().style.color = '#000000';
+  cell.getElement().style.color = getSeverityColor(overallLevel);
   return overallLevel;
 }
 

--- a/app/src/tabs/Import/styles.css
+++ b/app/src/tabs/Import/styles.css
@@ -133,15 +133,19 @@ span{
 }
 
 .Low {
-    color: black;
+    color: var(--severity-low);
 }
 
 .Medium {
-    color: orange;
+    color: var(--severity-medium);
 }
 
 .High {
-    color: red;
+    color: var(--severity-high);
+}
+
+.Critical {
+    color: var(--severity-critical);
 }
 
 .table {

--- a/app/src/tabs/Risks/renderer.js
+++ b/app/src/tabs/Risks/renderer.js
@@ -24,6 +24,20 @@
 
 /* global $ tinymce Tabulator */
 
+const { SEVERITY_COLORS = {} } = window.COLOR_CONSTANTS || {};
+const getSeverityColor = (level) => {
+  switch (level) {
+    case 'Critical':
+      return SEVERITY_COLORS.CRITICAL || '#D32A26';
+    case 'High':
+      return SEVERITY_COLORS.HIGH || '#E35623';
+    case 'Medium':
+      return SEVERITY_COLORS.MEDIUM || '#FAAB24';
+    default:
+      return SEVERITY_COLORS.LOW || '#000000';
+  }
+};
+
 // Display the buttons as not usable
 function disableButtons(){
   for (button of document.querySelectorAll('button')) button.disabled = true;
@@ -108,14 +122,9 @@ function enableInteract(){
     
     tableOptions.columns[riskLevelIndex].formatter = (cell) => {
       const residualRiskLevel = cell.getValue()
-      if (residualRiskLevel === 'Critical') cell.getElement().style.color = '#FF0000';
-      else if (residualRiskLevel === 'High') cell.getElement().style.color = '#E73927';
-      else if (residualRiskLevel === 'Medium') cell.getElement().style.color = '#FFA500';
-      else cell.getElement().style.color = '#000000';
-    
+      cell.getElement().style.color = getSeverityColor(residualRiskLevel);
       
       return residualRiskLevel;
-    
     }
     
     const risksTable = new Tabulator('#risks__table', result[1]);
@@ -858,17 +867,11 @@ function enableInteract(){
     };
 
     const styleResidualRiskLevelTable = (id, residualRiskLevel) => {
-      if (residualRiskLevel === 'Critical') risksTable.getRow(id).getCell('residualRiskLevel').getElement().style.color = '#FF0000';
-      else if (residualRiskLevel === 'High') risksTable.getRow(id).getCell('residualRiskLevel').getElement().style.color = '#E73927';
-      else if (residualRiskLevel === 'Medium') risksTable.getRow(id).getCell('residualRiskLevel').getElement().style.color = '#FFA500';
-      else risksTable.getRow(id).getCell('residualRiskLevel').getElement().style.color = '#000000';
+      risksTable.getRow(id).getCell('residualRiskLevel').getElement().style.color = getSeverityColor(residualRiskLevel);
     };
 
     const styleResidualRiskLevel = (residualRiskLevel) => {
-      if (residualRiskLevel === 'Critical') $('#residual_risk_level').css('color', '#FF0000');
-      else if (residualRiskLevel === 'High') $('#residual_risk_level').css('color', '#E73927');
-      else if (residualRiskLevel === 'Medium') $('#residual_risk_level').css('color', '#FFA500');
-      else $('#residual_risk_level').css('color', '#000000');
+      $('#residual_risk_level').css('color', getSeverityColor(residualRiskLevel));
     }
 
     const styleRiskName = (value, id) => {

--- a/app/src/tabs/Risks/risks.html
+++ b/app/src/tabs/Risks/risks.html
@@ -273,31 +273,31 @@
                                             </tr>
                                             <tr>
                                                 <td class='occurrence' data-occurrence="Very High" data-row="1">Very High</td>
-                                                <td style="background-color: orange;"><span>Medium</span></td>
-                                                <td style="background-color: red;"><span>High</span></td>
+                                                <td style="background-color: var(--severity-medium, #FAAB24); color: var(--severity-medium-contrast, #000000);"><span>Medium</span></td>
+                                                <td style="background-color: var(--severity-high, #E35623); color: var(--severity-high-contrast, #ffffff);"><span>High</span></td>
                                                 <td style="background-color: #9f204b;"><span>Very High</span></td>
                                                 <td style="background-color: #9f204b;"><span>High</span></td>
                                             </tr>
                                             <tr>
                                                 <td class='occurrence' data-occurrence="High" data-row="2">High</td>
-                                                <td style="background-color: orange;"><span>Medium</span></td>
-                                                <td style="background-color: orange;"><span>Medium</span></td>
-                                                <td style="background-color: red;"><span>High</span></td>
+                                                <td style="background-color: var(--severity-medium, #FAAB24); color: var(--severity-medium-contrast, #000000);"><span>Medium</span></td>
+                                                <td style="background-color: var(--severity-medium, #FAAB24); color: var(--severity-medium-contrast, #000000);"><span>Medium</span></td>
+                                                <td style="background-color: var(--severity-high, #E35623); color: var(--severity-high-contrast, #ffffff);"><span>High</span></td>
                                                 <td style="background-color: #9f204b;"><span>Very High</span></td>
                                             </tr>
                                             <tr>
                                                 <td class='occurrence' data-occurrence="Medium" data-row="3">Medium</td>
-                                                <td style="background-color: #38E54D;"><span>Low</span></td>
-                                                <td style="background-color: orange;"><span>Medium</span></td>
-                                                <td style="background-color: orange;"><span>Medium</span></td>
-                                                <td style="background-color: red;"><span>High</span></td>
+                                                <td style="background-color: var(--severity-low, #000000); color: var(--severity-low-contrast, #ffffff);"><span>Low</span></td>
+                                                <td style="background-color: var(--severity-medium, #FAAB24); color: var(--severity-medium-contrast, #000000);"><span>Medium</span></td>
+                                                <td style="background-color: var(--severity-medium, #FAAB24); color: var(--severity-medium-contrast, #000000);"><span>Medium</span></td>
+                                                <td style="background-color: var(--severity-high, #E35623); color: var(--severity-high-contrast, #ffffff);"><span>High</span></td>
                                             </tr>
                                             <tr>
                                                 <td class='occurrence' data-occurrence="Low" data-row="4">Low</td>
-                                                <td style="background-color: #38E54D;"><span>Low</span></td>
-                                                <td style="background-color: #38E54D;"><span>Low</span></td>
-                                                <td style="background-color: orange;"><span>Medium</span></td>
-                                                <td style="background-color: orange;"><span>Medium</span></td>
+                                                <td style="background-color: var(--severity-low, #000000); color: var(--severity-low-contrast, #ffffff);"><span>Low</span></td>
+                                                <td style="background-color: var(--severity-low, #000000); color: var(--severity-low-contrast, #ffffff);"><span>Low</span></td>
+                                                <td style="background-color: var(--severity-medium, #FAAB24); color: var(--severity-medium-contrast, #000000);"><span>Medium</span></td>
+                                                <td style="background-color: var(--severity-medium, #FAAB24); color: var(--severity-medium-contrast, #000000);"><span>Medium</span></td>
                                             </tr>
                                         </tbody>
                                         <tbody>

--- a/app/src/tabs/Vulnerabilities/renderer.js
+++ b/app/src/tabs/Vulnerabilities/renderer.js
@@ -23,6 +23,20 @@
 */
 /* global $ tinymce Tabulator */
 
+const { SEVERITY_COLORS = {} } = window.COLOR_CONSTANTS || {};
+const getSeverityColor = (level) => {
+  switch (level) {
+    case 'Critical':
+      return SEVERITY_COLORS.CRITICAL || '#D32A26';
+    case 'High':
+      return SEVERITY_COLORS.HIGH || '#E35623';
+    case 'Medium':
+      return SEVERITY_COLORS.MEDIUM || '#FAAB24';
+    default:
+      return SEVERITY_COLORS.LOW || '#000000';
+  }
+};
+
 (async () => {
     var fetchedData
     try {
@@ -73,9 +87,7 @@
 
     tableOptions.columns[overallLevelIndex].formatter = (cell) => {
         const overallLevel = cell.getValue()
-        if (overallLevel === 'High') cell.getElement().style.color = '#FF0000';
-        else if (overallLevel === 'Medium') cell.getElement().style.color = '#FFA500';
-        else cell.getElement().style.color = '#000000';
+        cell.getElement().style.color = getSeverityColor(overallLevel);
         return overallLevel;
     }
 

--- a/app/src/tabs/Vulnerabilities/styles.css
+++ b/app/src/tabs/Vulnerabilities/styles.css
@@ -129,15 +129,19 @@ span{
 }
 
 .Low {
-    color: black;
+    color: var(--severity-low);
 }
 
 .Medium {
-    color: orange;
+    color: var(--severity-medium);
 }
 
 .High {
-    color: red;
+    color: var(--severity-high);
+}
+
+.Critical {
+    color: var(--severity-critical);
 }
 
 .table {

--- a/app/src/tabs/Vulnerabilities/vulnerabilities.html
+++ b/app/src/tabs/Vulnerabilities/vulnerabilities.html
@@ -58,6 +58,7 @@
             </div>
         </div>
     </div>
+    <script src="../../constants/colors.js"></script>
     <script src="../../javascript/common.js"></script>
     <script src="./renderer.js"></script>
     <script src="../../javascript/tabs.js"></script>

--- a/lib/src/api/Risk/render-risks.js
+++ b/lib/src/api/Risk/render-risks.js
@@ -240,31 +240,31 @@ const renderRisks = () => {
                             </tr>
                             <tr>
                                 <td class='occurrence' data-occurrence="Very High" data-row="1">Very High</td>
-                                <td style="background-color: orange;"><span>Medium</span></td>
-                                <td style="background-color: red;"><span>High</span></td>
-                                <td style="background-color: #9f204b;"><span>Very High</span></td>
-                                <td style="background-color: #9f204b;"><span>Very High</span></td>
+                                <td style="background-color: var(--severity-medium-background, #ffa500); color: var(--severity-medium-contrast, #000000);"><span>Medium</span></td>
+                                <td style="background-color: var(--severity-high-background, #ff0000); color: var(--severity-high-contrast, #ffffff);"><span>High</span></td>
+                                <td style="background-color: var(--severity-very-high-background, #9f204b);"><span>Very High</span></td>
+                                <td style="background-color: var(--severity-very-high-background, #9f204b);"><span>Very High</span></td>
                             </tr>
                             <tr>
                                 <td class='occurrence' data-occurrence="High" data-row="2">High</td>
-                                <td style="background-color: orange;"><span>Medium</span></td>
-                                <td style="background-color: orange;"><span>Medium</span></td>
-                                <td style="background-color: red;"><span>High</span></td>
-                                <td style="background-color: #9f204b;"><span>Very High</span></td>
+                                <td style="background-color: var(--severity-medium-background, #ffa500); color: var(--severity-medium-contrast, #000000);"><span>Medium</span></td>
+                                <td style="background-color: var(--severity-medium-background, #ffa500); color: var(--severity-medium-contrast, #000000);"><span>Medium</span></td>
+                                <td style="background-color: var(--severity-high-background, #ff0000); color: var(--severity-high-contrast, #ffffff);"><span>High</span></td>
+                                <td style="background-color: var(--severity-very-high-background, #9f204b);"><span>Very High</span></td>
                             </tr>
                             <tr>
                                 <td class='occurrence' data-occurrence="Medium" data-row="3">Medium</td>
-                                <td style="background-color: #38E54D;"><span>Low</span></td>
-                                <td style="background-color: orange;"><span>Medium</span></td>
-                                <td style="background-color: orange;"><span>Medium</span></td>
-                                <td style="background-color: red;"><span>High</span></td>
+                                <td style="background-color: var(--severity-low-background, #38E54D); color: var(--severity-low-contrast, #ffffff);"><span>Low</span></td>
+                                <td style="background-color: var(--severity-medium-background, #ffa500); color: var(--severity-medium-contrast, #000000);"><span>Medium</span></td>
+                                <td style="background-color: var(--severity-medium-background, #ffa500); color: var(--severity-medium-contrast, #000000);"><span>Medium</span></td>
+                                <td style="background-color: var(--severity-high-background, #ff0000); color: var(--severity-high-contrast, #ffffff);"><span>High</span></td>
                             </tr>
                             <tr>
                                 <td class='occurrence' data-occurrence="Low" data-row="4">Low</td>
-                                <td style="background-color: #38E54D;"><span>Low</span></td>
-                                <td style="background-color: #38E54D;"><span>Low</span></td>
-                                <td style="background-color: orange;"><span>Medium</span></td>
-                                <td style="background-color: orange;"><span>Medium</span></td>
+                                <td style="background-color: var(--severity-low-background, #38E54D); color: var(--severity-low-contrast, #ffffff);"><span>Low</span></td>
+                                <td style="background-color: var(--severity-low-background, #38E54D); color: var(--severity-low-contrast, #ffffff);"><span>Low</span></td>
+                                <td style="background-color: var(--severity-medium-background, #ffa500 ); color: var(--severity-medium-contrast, #000000);"><span>Medium</span></td>
+                                <td style="background-color: var(--severity-medium-background, #ffa500); color: var(--severity-medium-contrast, #000000);"><span>Medium</span></td>
                             </tr>
                         </tbody>
                         <tbody>

--- a/lib/src/api/Vulnerability/handler-event.js
+++ b/lib/src/api/Vulnerability/handler-event.js
@@ -103,13 +103,14 @@ const updateVulnerability = (israProject, id, field, value) =>{
                 return dialog.showMessageBoxSync(getMainWindow(), { type: 'error', title: 'Invalid CVE Score', message: vulnerabilityErrorMsg });
 
             } else {
-
+                // console.log("HELLO PRINT CVESCORE", cveScore);
                 vulnerability.overallScore = !Number(cveScore) ? null : Math.round(cveScore);
                 vulnerability['cveScore'] = cveScore === null ? null : Number(cveScore);
                 if (cveScore < 4) vulnerability.overallLevel = 'Low';
                 else if (cveScore >= 4 && cveScore < 7) vulnerability.overallLevel = 'Medium';
-                else if (cveScore >= 7) vulnerability.overallLevel = 'High';
-
+                else if (cveScore >= 7 && cveScore < 9) vulnerability.overallLevel = 'High';
+                else if (cveScore >= 9) vulnerability.overallLevel = 'Critical';    
+                else vulnerability.overallLevel = null;
             }
         }
 


### PR DESCRIPTION

## Summary: 
Centralizes `Low`, `Medium`, `High`, `Critical` colours to a single source of truth and updates all usages for consistency. No functional changes.

## Changes

*   `app/src/global_styles/global-styles.css`: single `:root` with `--severity-*` and `--severity-*-contrast`.
*    All CSS pages: `.Low/.Medium/.High/.Critical` now use variables.
*   `app/src/tabs/Risks/risks.html`, `lib/src/api/Risk/render-risks.js` etc.: matrix cells use variables (with fallbacks) for background and contrast.
*   `app/src/constants/colors.js`: new JS palette (exports `SEVERITY_COLORS`, `SEVERITY_CONTRAST_COLORS`, and individual constants; also exposed on `window.COLOR_CONSTANTS`).
*   `app/src/tabs/Vulnerabilities/vulnerabilities.html`: load `../../constants/colors.js` before the renderer.

## Verify

*   Open Risks and Vulnerabilities tabs; colours for all severities match across labels and matrices.