### PR TITLE
Restore defensive checks in Supporting Asset validation helpers with guard clauses

### DIFF
--- a/app/src/electron/request-handlers.js
+++ b/app/src/electron/request-handlers.js
@@ -282,20 +282,26 @@ const validateClasses = () => {
     };
     
     // Check if the supportingAsset exists globally
-    const checkSupportingAssetRef = (ref) =>{
-      if (ref === null) return 
-      let foundSupportingAsset = SupportingAsset.find(obj => obj.supportingAssetId == ref);
-
+    const checkSupportingAssetRef = (ref) => {
+      if (ref === null) return false;
+      const foundSupportingAsset = SupportingAsset.find(
+        (obj) => obj.supportingAssetId == ref
+      );
+      if (!foundSupportingAsset) return false;
+      const { businessAssetRef = [], supportingAssetName } = foundSupportingAsset;
       if (
-        foundSupportingAsset.businessAssetRef.length == 0 ||
-        foundSupportingAsset.businessAssetRef.length !== new Set(foundSupportingAsset.businessAssetRef).size ||
-        !checkBusinessAssetRefArray(foundSupportingAsset.businessAssetRef) ||
-        foundSupportingAsset.supportingAssetName == ''
-      ){
-        return false
+        businessAssetRef.length === 0 ||
+        businessAssetRef.length !== new Set(businessAssetRef).size ||
+        !checkBusinessAssetRefArray(businessAssetRef) ||
+        supportingAssetName === ""
+      ) {
+        return false;
       }
-      return true
-  };
+      return true;
+    };
+
+
+
     // Check if the supportingAssets are valid
     const checkSupportingAssetRefArray = (refArray) =>{
       if(refArray.length){

--- a/app/src/tabs/Vulnerabilities/renderer.js
+++ b/app/src/tabs/Vulnerabilities/renderer.js
@@ -164,18 +164,26 @@ const getSeverityColor = (level) => {
         return true
     };
     // Check if the supportingAsset is valid
-    const checkSupportingAssetRef = (ref) =>{
-        if (ref === null) return 
-        let foundSupportingAsset = fetchedData.SupportingAsset.find(obj => obj.supportingAssetId == ref);
+    const checkSupportingAssetRef = (ref) => {
+      if (ref === null) return false;
+      const foundSupportingAsset = fetchedData.SupportingAsset.find(
+        (obj) => obj.supportingAssetId == ref
+      );
+      if (!foundSupportingAsset) return false;
 
-        if (foundSupportingAsset.businessAssetRef.length == 0 || 
-            foundSupportingAsset.businessAssetRef.length !== new Set(foundSupportingAsset.businessAssetRef).size || 
-            !checkBusinessAssetRefArray(foundSupportingAsset.businessAssetRef) || 
-            foundSupportingAsset.supportingAssetName == ''){
-            return false
-        }
-        return true
-      };
+      const { businessAssetRef = [], supportingAssetName } =
+        foundSupportingAsset;
+
+      if (
+        businessAssetRef.length === 0 ||
+        businessAssetRef.length !== new Set(businessAssetRef).size ||
+        !checkBusinessAssetRefArray(businessAssetRef) ||
+        supportingAssetName === ""
+      ) {
+        return false;
+      }
+      return true;
+    };
 
     // Check if the supportingAssets are valid
     const checkSupportingAssetRefArray = (refArray) =>{


### PR DESCRIPTION
## Description
This PR restores defensive checks in the Supporting Asset validation helpers so
the Vulnerabilities UI can render rows even when a vulnerability references a
deleted supporting asset.

## Additional Information
checkSupportingAssetRef exists in both the renderer (to colour rows) and the
Electron main process (to validate data before Save/Load). When either helper
dereferences a missing supporting asset, it throws, which previously caused the
vulnerabilities Tabulator row to vanish and could also interrupt validation runs.

The change mirrors the same guard in both locations so missing references simply
return false and surface as validation errors instead of exploding.

## Changes

`checkSupportingAssetRef` function

app/src/electron/request-handlers.js
   - Updated Supporting Asset validation.
   - Added a guard that returns false when no supporting asset is found, or when
     the asset lacks valid businessAssetRef entries or a name.
   - Safeguards potential Save/Load issue

app/src/tabs/Vulnerabilities/renderer.js
   - Updated Supporting Asset validation.
   - Mirrored the same guard in the UI helper to keep Tabulator from crashing
     when a vulnerability references a missing supporting asset.
     
Fixes #351 