### PR TITLE
chore: upgrade Electron (26.8.1)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {   
     "eslint.format.enable": true,
     "editor.codeActionsOnSave": {
-        "source.fixAll.eslint": true
+        "source.fixAll.eslint": "explicit"
     },
     "eslint.validate": ["javascript"]
 }

--- a/app/package.json
+++ b/app/package.json
@@ -15,7 +15,7 @@
         "dist-linux": "electron-builder -l",
         "dist-mac": "electron-builder -m",
         "dist-windows": "electron-builder -w"
-    },
+        },
     "build": {
         "fileAssociations": [
             {
@@ -37,13 +37,14 @@
             {
                 "from": "../lib",
                 "to": "lib",
-                "filter": [
-                    "**/*",
-                    "!**/node_modules/.bin",
-                    "!**/test/**"
-                ]
+                "filter": ["**/*", "!/node_modules", "!/test/**"]
+            },
+            {
+                "from": "../lib/node_modules",
+                "to": "lib/node_modules",
+                "filter": ["**/*", "!**/.bin"]
             }
-        ],
+            ],
         "mac": {
             "icon": "src/asset/isra-app-icon-512.png",
             "mergeASARs": false,
@@ -83,16 +84,16 @@
         },
         "appId": "com.thalesgroup.dis.sratool"
     },
-    "postinstall": "electron-builder install-app-deps",
     "dependencies": {
         "chart.js": "^4.3.2",
         "jquery": "^3.6.1",
         "tabulator-tables": "^5.3.4",
-        "tinymce": "^6.8.6"
+        "tinymce": "^6.8.6",
+        "xml2js": "^0.5.0"
     },
     "devDependencies": {
         "electron": "^22.3.27",
-        "electron-builder": "^24.13.3"
+        "electron-builder": "^26.15.3"
     },
     "overrides": {
         "got": "^11.8.5",

--- a/app/package.json
+++ b/app/package.json
@@ -89,7 +89,6 @@
         "jquery": "^3.6.1",
         "tabulator-tables": "^5.3.4",
         "tinymce": "^6.8.6",
-        "xml2js": "^0.5.0"
     },
     "devDependencies": {
         "electron": "^22.3.27",

--- a/app/package.json
+++ b/app/package.json
@@ -89,6 +89,7 @@
         "jquery": "^3.6.1",
         "tabulator-tables": "^5.3.4",
         "tinymce": "^6.8.6",
+        "xml2js": "^0.6.2"
     },
     "devDependencies": {
         "electron": "^22.3.27",


### PR DESCRIPTION
Electron Builder v26 no longer packaged the required modules from lib/node_modules into the final application resources, causing runtime dependency resolution issues.

Updated the build configuration to explicitly include:

lib resources required by the application
lib/node_modules dependencies needed at runtime