### PR TITLE
newest electron upgrade 26.15.3

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -99,7 +99,6 @@
         "jquery": "^3.6.1",
         "tabulator-tables": "^5.3.4",
         "tinymce": "^6.8.6",
-        "update": "^0.7.4",
         "xml2js": "^0.6.2"
     },
     "devDependencies": {


### PR DESCRIPTION
Updated the Electron build configuration to support Electron Builder v26.15.3 and address build issues encountered during packaging.

Changes include:

-Added a minimum Node.js requirement of >=22.13.0, as Electron Builder v26 and its dependencies require a newer Node.js runtime.
-Added an override for @noble/hashes under app-builder-lib to resolve dependency compatibility issues encountered during the build process.
-Updated Electron Builder to v26.15.3.
-Restored required runtime dependencies under lib/node_modules through extraResources. Previously, the build configuration excluded node_modules from packaged resources, which caused required libraries to be stripped from the final application bundle. The additional extraResources entry ensures these dependencies are copied back into the packaged application and remain available at runtime.