### PR TITLE
Issue 280 | Keep the focus on the previous panel scrolling

### DIFF
--- a/app/src/javascript/tabs.js
+++ b/app/src/javascript/tabs.js
@@ -227,6 +227,42 @@ $(document).keydown(function(e) {
   }
 });
 
+// Preserve and restore scroll positions of panels
+window.addEventListener('beforeunload', () => {
+  const activeTabElement = document.querySelector('.tab-button.active');
+  const scrollWrapper = document.querySelector('.scrollingWrapper');
+  if (activeTabElement && scrollWrapper) {
+    const activeTab = activeTabElement.getAttribute('data-id');
+    sessionStorage.setItem(`scroll-${activeTab}`, scrollWrapper.scrollTop);
+  }
+});
+
+window.addEventListener('DOMContentLoaded', () => {
+  const activeTabElement = document.querySelector('.tab-button.active');
+  const scrollWrapper = document.querySelector('.scrollingWrapper');
+  
+  if (activeTabElement && scrollWrapper) {
+    const activeTab = activeTabElement.getAttribute('data-id');
+    const savedScroll = sessionStorage.getItem(`scroll-${activeTab}`);
+    
+    if (savedScroll !== null) {
+      const targetScroll = parseInt(savedScroll, 10);
+      let attempts = 0;
+      
+      const interval = setInterval(() => {
+        if (scrollWrapper.scrollHeight > scrollWrapper.clientHeight) {
+          scrollWrapper.scrollTop = targetScroll;
+        }
+        
+        attempts++;
+        if (Math.abs(scrollWrapper.scrollTop - targetScroll) < 5 || attempts >= 15) {
+          clearInterval(interval);
+        }
+      }, 100);
+    }
+  }
+});
+
 // check if user is connected to internet
 // if (!navigator.onLine)
 


### PR DESCRIPTION
   1. Added Scroll Storing (tabs.js): Before navigating away from a tab (beforeunload event), the scroll container's (.scrollingWrapper) scrollTop is saved to sessionStorage with a key specific to that tab (e.g. scroll-risks).
   2. Added Scroll Restoration (tabs.js): Upon page load (DOMContentLoaded event), the saved scroll position for the current tab is retrieved. Since the application renders tab components (such as Tabulator tables) asynchronously, a short-lived, lightweight interval polling mechanism is used to progressively apply the target scroll position as the container is populated. The interval clears immediately when the target scroll position is successfully applied or after 1.5 seconds as a fallback.
   3. Verified Back-end: Ran the existing backend test suite in lib/ and confirmed all 311 tests pass successfully with zero regressions.