### PR TITLE
Issue# 302 | Add way to list Supported Asset not used by risks

### DIFF
--- a/app/src/tabs/Supporting Assets/renderer.js
+++ b/app/src/tabs/Supporting Assets/renderer.js
@@ -132,6 +132,32 @@ const DEFAULT_TEXT_COLOR = TEXT_COLOR.DEFAULT;
       ))
     }
 
+    // Inject 'Used in Risk(s)?' column dynamically
+    result[1].columns.push({
+      title: 'Used in Risk(s)?',
+      field: 'usedByRisk',
+      headerSort: true,
+      headerHozAlign: 'center',
+      hozAlign: 'center',
+      width: 120,
+      formatter: (cell) => {
+        const saId = cell.getRow().getData().supportingAssetId;
+        const usedSAIds = new Set();
+        if (fetchedData && fetchedData.Risk) {
+          fetchedData.Risk.forEach(r => {
+            if (r.supportingAssetRef !== null) {
+              usedSAIds.add(Number(r.supportingAssetRef));
+            }
+          });
+        }
+        if (usedSAIds.has(Number(saId))) {
+          return `<span style="color: green;">Yes</span>`;
+        } else {
+          return `<span style="color: ${ERROR_COLOR}; font-weight: bold;">No</span>`;
+        }
+      }
+    });
+
     const supportingAssetsTable = new Tabulator('#supporting-assets__section-table', result[1]);
 
     const updateSupportingAsset = (id, field, value) => {

--- a/lib/test/integration/supporting-asset-column/supporting-asset-renderer-column.test.js
+++ b/lib/test/integration/supporting-asset-column/supporting-asset-renderer-column.test.js
@@ -1,0 +1,46 @@
+/*----------------------------------------------------------------------------
+*
+*     Copyright © 2026 THALES. All Rights Reserved.
+*
+* -----------------------------------------------------------------------------
+* THALES MAKES NO REPRESENTATIONS OR WARRANTIES ABOUT THE SUITABILITY OF
+* THE SOFTWARE, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+* TO THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+* PARTICULAR PURPOSE, OR NON-INFRINGEMENT. THALES SHALL NOT BE
+* LIABLE FOR ANY DAMAGES SUFFERED BY LICENSEE AS A RESULT OF USING,
+* MODIFYING OR DISTRIBUTING THIS SOFTWARE OR ITS DERIVATIVES.
+*
+* THIS SOFTWARE IS NOT DESIGNED OR INTENDED FOR USE OR RESALE AS ON-LINE
+* CONTROL EQUIPMENT IN HAZARDOUS ENVIRONMENTS REQUIRING FAIL-SAFE
+* PERFORMANCE, SUCH AS IN THE OPERATION OF NUCLEAR FACILITIES, AIRCRAFT
+* NAVIGATION OR COMMUNICATION SYSTEMS, AIR TRAFFIC CONTROL, DIRECT LIFE
+* SUPPORT MACHINES, OR WEAPONS SYSTEMS, IN WHICH THE FAILURE OF THE
+* SOFTWARE COULD LEAD DIRECTLY TO DEATH, PERSONAL INJURY, OR SEVERE
+* PHYSICAL OR ENVIRONMENTAL DAMAGE ("HIGH RISK ACTIVITIES"). THALES
+* SPECIFICALLY DISCLAIMS ANY EXPRESS OR IMPLIED WARRANTY OF FITNESS FOR
+* HIGH RISK ACTIVITIES.
+* -----------------------------------------------------------------------------
+*/
+
+const fs = require('fs');
+const path = require('path');
+
+describe('Supporting Assets renderer unused assets column', () => {
+  const rendererPath = path.resolve(__dirname, '../../../../app/src/tabs/Supporting Assets/renderer.js');
+  const rendererSource = fs.readFileSync(rendererPath, 'utf8');
+
+  test('dynamically injects the "Used in Risk(s)?" column before Tabulator instantiation', () => {
+    // Assert that columns.push is called with title 'Used in Risk(s)?'
+    expect(rendererSource).toMatch(/columns\.push\(\{[\s\S]*title:\s*['"]Used in Risk\(s\)\?['"]/);
+  });
+
+  test('uses the configured ERROR_COLOR for unused assets', () => {
+    // Assert that ERROR_COLOR is used inside the formatter
+    expect(rendererSource).toMatch(/color:\s*\${ERROR_COLOR}/);
+  });
+
+  test('enables header sorting on the newly added column', () => {
+    // Assert that headerSort is true on the new column
+    expect(rendererSource).toMatch(/headerSort:\s*true/);
+  });
+});


### PR DESCRIPTION
Changes Done:
We implemented an interactive, in-place "Used in Risk(s)?" column directly within the existing Supporting Assets
  Tabulator data grid inside app/src/tabs/Supporting Assets/renderer.js
  
  DevTest: Done (new column is present and with old sra file as well it is visible.