### PR TITLE
Issue#275 | Focus does not move newly added item when click on add button

### DIFF
--- a/app/src/tabs/Risks/renderer.js
+++ b/app/src/tabs/Risks/renderer.js
@@ -1206,6 +1206,9 @@ function enableInteract(){
       applyCurrentSort();
       risksTable.deselectRow();
       risksTable.selectRow(risk.riskId);
+      risksTable.scrollToRow(risk.riskId, "bottom", false).catch((err) => {
+        console.log("Error scrolling to new risk row:", err);
+      });
       disableInteract()
       await addSelectedRowData(risk.riskId);
       enableInteract()

--- a/app/src/tabs/Vulnerabilities/renderer.js
+++ b/app/src/tabs/Vulnerabilities/renderer.js
@@ -482,13 +482,13 @@ const getSeverityColor = (level) => {
         $('#vulnerabilities section').show();
         vulnerabilitiesData.push(vulnerability[0]);
         addVulnerability(vulnerability[0]);
-        if (vulnerabilitiesData.length === 0) vulnerabilitiesTable.selectRow(vulnerabilitiesData[0].vulnerabilityId);
         
-        // vulnerabilitiesData.forEach((v)=>{
-        //     vulnerabilitiesTable.deselectRow(v.vulnerabilityId);
-        // });
-
-        // addSelectedVulnerabilityRowData(vulnerability[0].vulnerabilityId);
+        vulnerabilitiesTable.deselectRow();
+        vulnerabilitiesTable.selectRow(vulnerability[0].vulnerabilityId);
+        vulnerabilitiesTable.scrollToRow(vulnerability[0].vulnerabilityId, "bottom", false).catch(err => {
+            console.log("Error scrolling to new vulnerability row:", err);
+        });
+        addSelectedVulnerabilityRowData(vulnerability[0].vulnerabilityId);
     });
 
     // delete Vulnerability button


### PR DESCRIPTION
Changes Made

   1. Risks Tab (app/src/tabs/Risks/renderer.js)
      - Added risksTable.scrollToRow(risk.riskId, "bottom", false) immediately after the programmatic selection. This
        automatically scrolls the Tabulator view to the bottom (or to the position of the newly added risk) to show it
        in the viewport.

   2. Vulnerabilities Tab (app/src/tabs/Vulnerabilities/renderer.js)
      - Fixed a selection logic bug where new vulnerabilities were not selected if there was already one or more
        vulnerabilities in the dataset (caused by an incorrect length comparison: if (vulnerabilitiesData.length ===
        0)).
      - Structured the Add button click handler to always deselect current rows, select the new vulnerability, load its
        detail data on the right-hand panel, and scroll the Tabulator list into view using
        vulnerabilitiesTable.scrollToRow(vulnerability[0].vulnerabilityId, "bottom", false).

  ---

  Verification & Testing

  1. Automated Tests
  Ran the local JEST test suite to verify no regressions were introduced.
   - Command: npm run test (executed from the lib directory)
   - Result: 311 tests passed (including integration source analysis in risk-renderer-dom.test.js).

  2. Manual Verification Steps
   1. Launch the Electron application.
   2. Navigate to the Risks tab and click the Add button.
      - Expected: A new risk is added, selected, the table viewport automatically scrolls to the bottom to focus on it,
        and the details form updates on the right.
   3. Navigate to the Vulnerabilities tab and click the Add button.
      - Expected: A new vulnerability is added, selected, the table viewport automatically scrolls to the bottom to
        focus on it, and the details form updates on the right