### PR TITLE
docs: add user guide with asset criticality and likelihood evaluation guidelines

### DIFF
--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -1,0 +1,56 @@
+---
+name: security-reviewer
+description: Electron security specialist for ISRA. Reviews code changes against Electron security best practices, OWASP Desktop App Top 10, and IPC input sanitization. Use when reviewing changes to app/src/electron/, preload.js, request-handlers.js, or lib/src/api/xml-json/.
+---
+
+You are a security reviewer specializing in Electron desktop applications and the ISRA security risk assessment tool (ThalesGroup/security-risk-assessment-tool).
+
+## Your Focus Areas
+
+### Electron Security Hardening
+- Verify `contextIsolation: true` and `nodeIntegration: false` are set in all `BrowserWindow` configs
+- Ensure `webSecurity` is not disabled
+- Check that `allowRunningInsecureContent` is not enabled
+- Verify `sandbox` option usage
+- Flag any use of deprecated `remote` module
+
+### preload.js / contextBridge
+- All exposed APIs must go through `contextBridge.exposeInMainWorld`
+- IPC channel whitelists must be maintained — no wildcard channel forwarding
+- Renderer must never receive raw Node.js objects
+- No sensitive data (file paths, system info) should leak to renderer unnecessarily
+
+### IPC Handler Security (request-handlers.js)
+- All `ipcMain.handle` / `ipcMain.on` handlers must validate and sanitize their inputs
+- File paths from renderer must be validated (check for path traversal: `../`, absolute paths to sensitive locations)
+- Never `eval()` or `new Function()` with renderer-supplied data
+- Check that `event.sender` is trusted before processing sensitive IPC messages
+
+### Input Sanitization (lib/src/api/xml-json/)
+- XML parsing via `xml2js` — check for XXE (external entity injection) risks
+- Rich text from TinyMCE must be sanitized before storing — watch for stored XSS
+- URL validation must restrict to allowed schemes: `ftp`, `http`, `https`, `mailto`, `tel`, `urn`
+- File attachment base64 encoding — verify size limits and content type checks
+
+### File I/O Security (lib/src/api/data-load/, data-store/)
+- Validate file extensions before loading (`.sra` or `.xml` only)
+- Check for path traversal in user-supplied file paths
+- JSON.parse of untrusted file content should be wrapped in try/catch
+- Large file handling — check for denial-of-service via oversized input
+
+### Dependency Security
+- Flag use of known vulnerable package versions
+- Check that devDependencies are not bundled in production builds
+
+## Review Output Format
+
+For each finding, report:
+```
+[SEVERITY: Critical/High/Medium/Low/Info]
+File: <path>:<line>
+Issue: <what the problem is>
+Risk: <what an attacker could do>
+Fix: <specific recommendation>
+```
+
+Focus only on actionable security findings. Do not report style issues or non-security concerns.

--- a/.claude/agents/test-writer.md
+++ b/.claude/agents/test-writer.md
@@ -1,0 +1,89 @@
+---
+name: test-writer
+description: Jest test generator for the ISRA lib module. Writes unit and integration tests following existing patterns. Use when asked to add tests for lib/src/ code — model classes, API handlers, or data load/store functions.
+---
+
+You are a Jest test writer for the ISRA security risk assessment tool's `lib` module (ThalesGroup/security-risk-assessment-tool).
+
+## Project Test Setup
+
+- **Runner**: Jest 29 with `--coverage`
+- **Config**: In `lib/package.json`, `testPathPattern: "test"`
+- **Unit tests**: `lib/test/unit/<topic>/<name>.test.js`
+- **Integration tests**: `lib/test/integration/<test-N>/<name>.test.js`
+- **Fixtures**: JSON fixture files placed alongside the integration test file
+
+## Patterns to Follow
+
+### Model Class Unit Tests
+Test each setter with valid values, invalid values (expect AJV validation errors), and edge cases.
+
+```javascript
+const ISRAProject = require('../../../src/model/classes/ISRAProject/isra-project');
+
+describe('ISRAProject', () => {
+  let project;
+
+  beforeEach(() => {
+    project = new ISRAProject();
+  });
+
+  describe('projectName setter', () => {
+    test('accepts valid string', () => {
+      project.projectName = 'My Assessment';
+      expect(project.projectName).toBe('My Assessment');
+    });
+
+    test('throws on non-string', () => {
+      expect(() => { project.projectName = 123; }).toThrow();
+    });
+  });
+});
+```
+
+### AJV Validation Tests
+```javascript
+const { validate } = require('../../../src/model/classes/validation/ajv-instance');
+
+test('rejects invalid URL scheme', () => {
+  const result = validate(schema, { trackingUrl: 'javascript:alert(1)' });
+  expect(result).toBe(false);
+});
+```
+
+### Integration Tests (round-trip load/save)
+```javascript
+const { loadJSONFile } = require('../../../src/api/data-load');
+const path = require('path');
+
+describe('Integration test: project load', () => {
+  test('loads valid .sra file without errors', async () => {
+    const filePath = path.join(__dirname, 'fixture.sra');
+    const project = await loadJSONFile(filePath);
+    expect(project).toBeDefined();
+    expect(project.BusinessAssets).toBeDefined();
+  });
+});
+```
+
+### Handler Event Tests
+Mock ipcRenderer events and verify correct handler behavior:
+```javascript
+jest.mock('electron', () => ({
+  ipcRenderer: { on: jest.fn(), send: jest.fn() }
+}));
+```
+
+## What to Test
+
+When given a file or feature to test, cover:
+1. **Happy path** — valid inputs produce expected output
+2. **Invalid input** — AJV validation errors are thrown for bad data
+3. **Edge cases** — empty strings, null, undefined, boundary values
+4. **Round-trips** — for serialization code, verify `load(save(x)) === x`
+
+## File Naming
+- Unit: `lib/test/unit/<topic>/<descriptive-name>.test.js`
+- Integration: `lib/test/integration/<test-N>/<name>.test.js`
+
+Always `require` modules using relative paths from the test file location.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,28 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node -e \"let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{try{const j=JSON.parse(d);const f=(j.tool_input||{}).file_path||'';if(f.includes('lib')&&(f.endsWith('.js')||f.endsWith('.mjs'))){const p=require('path');const s=require('child_process').spawnSync('npx',['eslint','--fix',f],{cwd:p.join(process.cwd(),'lib'),shell:true,encoding:'utf8'});if(s.stdout)process.stdout.write(s.stdout);if(s.stderr)process.stderr.write(s.stderr);}}catch(e){}});\"",
+            "description": "Auto-lint lib JS files with ESLint after edit"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node -e \"let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{try{const j=JSON.parse(d);const f=(j.tool_input||{}).file_path||'';if(f.endsWith('package-lock.json')){process.stderr.write('BLOCKED: Do not edit package-lock.json directly. Run npm install instead.\\n');process.exit(2);}}catch(e){}});\"",
+            "description": "Block direct edits to package-lock.json"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/project-conventions/SKILL.md
+++ b/.claude/skills/project-conventions/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: project-conventions
+description: ISRA project conventions — data model, IPC pattern, validation approach, file format, and code organization rules. Load this before generating or reviewing code for this project.
+user-invocable: false
+---
+
+# ISRA Project Conventions
+
+## Monorepo Rule
+All business logic belongs in `lib/src/`. The `app/` directory is Electron UI only — it must never contain business logic.
+
+## Data Model Hierarchy
+```
+ISRAProject → ISRAProjectContext
+            → BusinessAsset[] (→ BusinessAssetProperties)
+            → SupportingAsset[]
+            → Risk[] (→ RiskAttackPath[], RiskImpact, RiskLikelihood, RiskMitigation[])
+            → Vulnerability[]
+```
+Each entity class: `lib/src/model/classes/<ClassName>/<classname>.js`  
+Each entity validation: `lib/src/model/classes/<ClassName>/validation.js`
+
+## IPC Pattern
+Renderer → `preload.js` contextBridge → `ipcMain` handler in `request-handlers.js` → `lib/src/api/` function.
+
+Never import lib directly in renderer code. All channels must be explicitly whitelisted in `preload.js`.
+
+## Validation Pattern
+Use AJV 8 with the centralized instance from `lib/src/model/classes/validation/ajv-instance.js`.  
+Validate in property setters via `validateClassProperties` from `lib/src/model/classes/validation/validate-class-properties.js`.  
+Schema definitions in `lib/src/model/schema/json-schema.js`.
+
+## File I/O
+- `.sra` = JSON (primary format)
+- XML supported via `xml2js` for legacy migration
+- Load: `lib/src/api/data-load/`
+- Save: `lib/src/api/data-store/`
+- Sanitize all external content (URLs, rich text) in `lib/src/api/xml-json/`
+
+## Testing
+- Jest 29, files in `lib/test/unit/` and `lib/test/integration/`
+- Integration tests use JSON fixture files alongside the test file
+- Run: `cd lib && npm run test`
+
+## Allowed URL Schemes
+For vulnerability tracking URLs: `ftp`, `http`, `https`, `mailto`, `tel`, `urn` only.
+
+## Electron Security
+- Keep `nodeIntegration: false`, `contextIsolation: true`
+- All IPC channels must be whitelisted
+- Sanitize TinyMCE (rich text) output before storing

--- a/.claude/skills/run-tests/SKILL.md
+++ b/.claude/skills/run-tests/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: run-tests
+description: Run the Jest test suite for the lib module with coverage report. Use this to check that all unit and integration tests pass after making changes to lib/src/.
+disable-model-invocation: true
+---
+
+Run the Jest test suite with coverage for the `lib` module:
+
+```bash
+cd lib && npm run test
+```
+
+This runs all tests in `lib/test/unit/` and `lib/test/integration/` with coverage output.

--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,27 @@
+# Dependencies
+node_modules/
+
+# Build output
+dist/
+coverage/
+
+# Generated API docs
+lib/doc/APIdocumentation/
+
+# Binary / image assets (no value to read)
+app/src/asset/*.png
+app/src/asset/*.ico
+app/src/asset/*.jpg
+app/src/asset/*.gif
+app/src/asset/*.svg
+
+# Test fixture data files (large JSON/XML, Claude reads these on demand)
+lib/test/integration/fixtures/
+
+# Office documents
+doc/*.xlsx
+
+# Lock files
+package-lock.json
+app/package-lock.json
+lib/package-lock.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,94 @@
+# ISRA — Security Risk Assessment Tool
+
+Electron desktop application for ISO 27005 security risk assessments. Fully offline, file-based storage (no network calls, no database).
+
+## Monorepo Structure
+
+```
+lib/    Core business logic (npm module, framework-agnostic)
+app/    Electron desktop app (UI only, delegates all logic to lib)
+```
+
+**Rule**: Business logic always goes in `lib/`. `app/` only handles IPC and DOM rendering.
+
+## Running the Project
+
+```bash
+# Dev app (from repo root)
+cd app && npm start
+
+# Run tests with coverage (from repo root)
+cd lib && npm run test
+
+# Generate JSDoc
+cd lib && npm run jsdoc
+
+# Build distributable
+cd app && npm run dist
+```
+
+## IPC Architecture
+
+```
+Renderer (tabs/*.js)
+  → contextBridge (preload.js)
+    → ipcRenderer.send / ipcRenderer.invoke
+      → ipcMain handlers (request-handlers.js)
+        → lib API (lib/src/api/)
+```
+
+Never call `lib` functions directly from renderer. Always go through the contextBridge → ipcMain chain.
+
+## Data Model (ISO 27005)
+
+```
+ISRAProject
+  ├── ISRAProjectContext       (scope, assumptions, trust boundaries)
+  ├── BusinessAsset[]          (primary assets — what has business value)
+  │     └── BusinessAssetProperties  (security sub-characteristics: CIA, authenticity, etc.)
+  ├── SupportingAsset[]        (technical assets — where business assets flow/reside)
+  ├── Risk[]                   (threat + vulnerability + scenario + treatment)
+  │     ├── RiskAttackPath[]   (AND/OR combinations of vulnerabilities)
+  │     ├── RiskImpact         (per-security-characteristic impact scores)
+  │     ├── RiskLikelihood     (likelihood scores)
+  │     └── RiskMitigation[]   (proposed security controls with benefit %)
+  └── Vulnerability[]          (scored 0-10, linked to SupportingAssets)
+```
+
+Each class lives in `lib/src/model/classes/<ClassName>/`. AJV JSON Schema is in `lib/src/model/schema/json-schema.js`.
+
+## Validation Pattern
+
+All model classes use AJV for property validation. The AJV instance is in `lib/src/model/classes/validation/ajv-instance.js`. To add a new validated field:
+1. Add the property to the JSON Schema in `json-schema.js`
+2. Use `validateClassProperties` from `lib/src/model/classes/validation/validate-class-properties.js` in the setter
+
+## File Format
+
+- `.sra` files are JSON (the primary project format)
+- XML format is supported for legacy InfoPath migration via `xml2js`
+- File I/O lives in `lib/src/api/data-load/` (open) and `lib/src/api/data-store/` (save)
+
+## Testing
+
+Tests are in `lib/test/`:
+- `unit/` — class-level tests, schema validation, utility functions
+- `integration/` — full project load/save round-trips using fixture files in `lib/test/integration/test-N/`
+
+Run with: `cd lib && npm run test` (Jest 29, coverage included).
+
+## Linting
+
+ESLint 8 configured at `lib/.eslintrc.json`. Scoped to `lib/` only (no eslint in `app/`).
+
+## Electron Security Notes
+
+- `nodeIntegration` must remain disabled
+- `contextIsolation` must remain enabled
+- All IPC channels are whitelisted in `preload.js` — add new channels explicitly
+- URL schemes allowed for vulnerabilities: `ftp`, `http`, `https`, `mailto`, `tel`, `urn`
+- Sanitize all rich text (TinyMCE output) before persisting — see `xml-json/` sanitization
+
+## Config Defaults
+
+Customizable in `lib/src/config.js`: `appVersion`, `classification`, `organizations`.

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -1,0 +1,141 @@
+# Architecture Overview
+
+> **Audience:** Newcomers / onboarding developers  
+> **Scope:** High-level structure of the ISRA Security Risk Assessment Tool — what exists, why it is split the way it is, and which layer owns what.
+
+---
+
+## Purpose & Scope
+
+ISRA is an **offline Electron desktop application** that guides security engineers through an ISO 27005 risk assessment. It has no server, no database, and makes no network calls during normal use. All project data is stored in `.sra` files (JSON) on the local filesystem.
+
+The project is intentionally split into two packages so that the **core business logic can be tested and reused independently** of any UI framework:
+
+- `lib/` — pure Node.js module, framework-agnostic, unit-testable
+- `app/` — Electron shell, UI only, delegates all logic to `lib/`
+
+This document explains the top-level structure and how these two layers communicate.
+
+---
+
+## Monorepo Structure
+
+```
+security-risk-assessment-tool/
+├── lib/                   Core business logic (npm module)
+│   ├── src/
+│   │   ├── config.js          App-wide config (version, classification, orgs)
+│   │   ├── utility-global.js  Shared utilities (counter helper)
+│   │   ├── model/
+│   │   │   ├── classes/       Domain entity classes (ISRAProject, Risk, …)
+│   │   │   └── schema/        AJV JSON Schema definition
+│   │   └── api/               Public API: DataLoad, DataStore, DataNew, XML2JSON
+│   └── test/
+│       ├── unit/              Unit tests per class / utility
+│       └── integration/       Full load/save round-trips with fixture files
+│
+└── app/                   Electron desktop application (UI only)
+    └── src/
+        ├── electron/
+        │   ├── main.js            App entry point, creates BrowserWindow
+        │   ├── preload.js         contextBridge — exposes safe IPC APIs to renderer
+        │   ├── request-handlers.js  ipcMain handlers — calls lib API
+        │   └── validation.js      Error message strings
+        ├── tabs/                  Per-tab HTML/JS UI modules
+        │   ├── Welcome/
+        │   ├── Project Context/
+        │   ├── Business Assets/
+        │   ├── Supporting Assets/
+        │   ├── Risks/
+        │   ├── Vulnerabilities/
+        │   └── Report/
+        ├── javascript/            Shared renderer JS (tabs.js, common.js)
+        └── asset/                 Icons and images
+```
+
+**The single most important rule:** business logic always goes in `lib/`. `app/` only handles IPC dispatch and DOM rendering. Never call `lib` functions directly from the renderer process.
+
+---
+
+## Key Components & Responsibilities
+
+| Component | Location | Responsibility |
+|---|---|---|
+| `ISRAProject` | `lib/src/model/classes/ISRAProject/` | Root domain object; owns all child entity maps |
+| `BusinessAsset` | `lib/src/model/classes/BusinessAsset/` | Primary assets (what has business value) |
+| `SupportingAsset` | `lib/src/model/classes/SupportingAsset/` | Technical assets (where business assets reside) |
+| `Risk` | `lib/src/model/classes/Risk/` | Threat scenario + likelihood + impact + mitigations |
+| `Vulnerability` | `lib/src/model/classes/Vulnerability/` | Weakness scored 0–10, linked to SupportingAssets |
+| `ISRAProjectContext` | `lib/src/model/classes/ISRAProjectContext/` | Scope, assumptions, trust boundaries |
+| `ISRAMetaTracking` | `lib/src/model/classes/ISRAProject/` | Audit trail of assessment iterations |
+| `json-schema.js` | `lib/src/model/schema/` | AJV JSON Schema — single source of truth for valid data shapes |
+| `api/DataLoad` | `lib/src/api/data-load/` | Open `.sra` / `.json` file → populate `ISRAProject` |
+| `api/DataStore` | `lib/src/api/data-store/` | Serialize `ISRAProject` → write `.sra` file |
+| `api/DataNew` | `lib/src/api/data-new/` | Initialize a blank `ISRAProject` |
+| `api/XML2JSON` | `lib/src/api/xml-json/` | Parse legacy InfoPath XML → `ISRAProject` |
+| `request-handlers.js` | `app/src/electron/` | All ipcMain handlers; owns the live `israProject` instance |
+| `preload.js` | `app/src/electron/` | Whitelisted contextBridge — the only bridge between renderer and main |
+| `tabs/*.js` | `app/src/tabs/` | Per-tab renderer code; reads/writes via `window.render`, `window.validate`, etc. |
+
+---
+
+## Technology Stack
+
+| Concern | Technology | Version / Notes |
+|---|---|---|
+| Desktop shell | Electron | Chromium renderer + Node.js main process |
+| Business logic | Node.js (CommonJS) | No TypeScript; plain ES2020 classes |
+| Validation | AJV 8 | JSON Schema draft-07 |
+| XML parsing | xml2js | Legacy InfoPath migration only |
+| Rich text editing | TinyMCE | Used in several description fields |
+| Testing | Jest 29 | Coverage included (`npm run test`) |
+| Linting | ESLint 8 | Configured at `lib/.eslintrc.json`; `lib/` only |
+| Build | electron-builder | `npm run dist` from `app/` |
+
+---
+
+## IPC Flow (Overview)
+
+The renderer process has **no direct access** to Node.js APIs or to `lib`. All data flows through a strictly whitelisted IPC bridge:
+
+```
+Renderer (tabs/*.js)
+  │  calls window.render.risks() etc.
+  ▼
+contextBridge (preload.js)
+  │  ipcRenderer.invoke('render:risks')
+  ▼
+ipcMain handler (request-handlers.js)
+  │  calls lib API e.g. DataLoad, israProject.addRisk()
+  ▼
+lib API (lib/src/api/)
+  │  mutates ISRAProject in memory
+  ▼
+returns JSON string back to renderer
+```
+
+See [IPC Architecture](features/ipc-architecture.md) for the full channel reference and how to add a new channel.
+
+---
+
+## Operational Notes
+
+- **Where does new business logic go?** Always `lib/src/`. Add a class under `lib/src/model/classes/<Entity>/`, expose it through `lib/src/api/`, and wire up a new IPC handler in `app/src/electron/request-handlers.js`.
+- **Where does new UI go?** Under `app/src/tabs/<TabName>/`. A tab gets its data by calling `window.render.<tabName>()` on load and sends mutations via `window.validate.<tabName>(data)` or similar channels.
+- **No env vars** — all configuration is in `lib/src/config.js` (`appVersion`, `classification`, `organizations`).
+- **No feature flags** — there are no `FF_*` flags in this codebase.
+
+---
+
+## Assumptions Made
+
+- The project has no HTTP server; it is fully offline. OpenAPI documentation is not applicable.
+- `lib/` is scoped as a private npm module consumed directly by `app/` via a relative path (`require('../../../lib/src/...')`).
+- The Electron version in use follows the security settings documented in [Electron Security](features/electron-security.md).
+
+## Open Questions
+
+- Which version of Electron is currently in use? (Not specified in `package.json` excerpts reviewed.)
+- Is there a planned upgrade path to ESM / TypeScript for `lib/`?
+
+## Last Reviewed: 2026-06-24

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,0 +1,268 @@
+# Data Model
+
+> **Audience:** Newcomers / onboarding developers  
+> **Scope:** All domain entity classes in `lib/src/model/classes/`, their properties, relationships, and lifecycle methods (add / delete / get).
+
+---
+
+## Purpose & Scope
+
+The ISRA data model represents an ISO 27005 security risk assessment as a tree of in-memory JavaScript class instances rooted at `ISRAProject`. Each class:
+
+- Uses **private fields** (`#field`) for encapsulation.
+- Validates every property assignment via AJV (see [Validation Pattern](features/validation-pattern.md)).
+- Exposes a `.properties` getter that returns a plain object suitable for serialization.
+- Is stored inside its parent's `Map` (keyed by ID), not as arrays.
+
+The serialized form of a project is a single JSON string produced by `ISRAProject.toJSON()`, which writes the `.sra` file.
+
+---
+
+## Domain Entity Overview
+
+| Class | Location | Role |
+|---|---|---|
+| `ISRAProject` | `ISRAProject/isra-project.js` | Root container; owns all child maps |
+| `ISRAProjectContext` | `ISRAProjectContext/isra-project-context.js` | Scope, assumptions, trust boundaries |
+| `ISRAMetaTracking` | `ISRAProject/isra-meta-tracking.js` | One audit-trail entry per save iteration |
+| `BusinessAsset` | `BusinessAsset/business-asset.js` | Primary asset (what has business value) |
+| `BusinessAssetProperties` | `BusinessAsset/business-asset-properties.js` | CIA + Authenticity/Authorization/Non-repudiation sub-scores |
+| `SupportingAsset` | `SupportingAsset/supporting-asset.js` | Technical asset (where business assets reside/flow) |
+| `Risk` | `Risk/risk.js` | Threat scenario: agent + verb + motivation + scores |
+| `RiskLikelihood` | `Risk/risk-likelihood.js` | Likelihood scoring sub-object |
+| `RiskImpact` | `Risk/risk-impact.js` | Impact scoring per security characteristic |
+| `RiskAttackPath` | `Risk/risk-attack-path.js` | One AND/OR combination of vulnerability references |
+| `RiskMitigation` | `Risk/risk-mitigation.js` | A proposed security control with benefit % |
+| `Vulnerability` | `Vulnerability/vulnerability.js` | Weakness scored 0–10, linked to ≥1 SupportingAssets |
+
+---
+
+## Class Details
+
+### ISRAProject
+
+The root object. Constructed with `new ISRAProject()` and initialized by `DataNew` or populated by `DataLoad` / `XML2JSON`.
+
+**Key properties:**
+
+| Property | Type | Description |
+|---|---|---|
+| `projectName` | `string` | Free-text name of the assessed project |
+| `projectVersion` | `string` | Version string of the assessed project |
+| `projectOrganization` | `string` | Must be one of the values in `config.organizations` |
+| `classification` | `string` | Document classification label (default: `config.classification`) |
+| `iteration` | `integer \| null` | Current assessment iteration count |
+| `appVersion` | `string` | Read-only; set from `config.appVersion` at construction |
+| `schemaVersion` | `integer` | Schema version used to validate the file (max: 3) |
+| `latestBusinessAssetId` | `integer \| null` | Monotonically increasing ID counter (persisted across saves) |
+| `latestSupportingAssetId` | `integer \| null` | Same, for SupportingAssets |
+| `latestRiskId` | `integer \| null` | Same, for Risks |
+| `latestVulnerabilityId` | `integer \| null` | Same, for Vulnerabilities |
+
+**Child collections (Maps):**
+
+| Map field | Key | Value |
+|---|---|---|
+| `#businessAssetsMap` | `businessAssetId` | `BusinessAsset` instance |
+| `#supportingAssetsMap` | `supportingAssetId` | `SupportingAsset` instance |
+| `#risksMap` | `riskId` | `Risk` instance |
+| `#vulnerabilitiesMap` | `vulnerabilityId` | `Vulnerability` instance |
+| `#metaTrackingMap` | `trackingIteration` | `ISRAMetaTracking` instance |
+
+**Lifecycle methods** (identical pattern for each entity type):
+
+```js
+// Add — throws if wrong type
+israProject.addBusinessAsset(new BusinessAsset());
+
+// Get — throws if ID doesn't exist
+const ba = israProject.getBusinessAsset(1);
+
+// Delete — throws if ID doesn't exist; reindexes map
+israProject.deleteBusinessAsset(1);
+```
+
+> **Note:** When a Risk or Vulnerability is added, `ISRAProject` automatically copies `projectName` and `projectVersion` onto the child object to keep references consistent.
+
+---
+
+### BusinessAsset
+
+Represents something of value to the business (e.g. user credentials, transaction data, a service).
+
+**Key properties:**
+
+| Property | Type | Description |
+|---|---|---|
+| `businessAssetId` | `integer \| null` | Auto-incremented at construction |
+| `businessAssetName` | `string` | Free-text name |
+| `businessAssetType` | `string` | Enum defined in JSON Schema |
+| `businessAssetDescription` | `string` | HTML (TinyMCE) rich text |
+| `businessAssetProperties` | `BusinessAssetProperties` | CIA + extended security characteristics |
+
+`BusinessAssetProperties` carries per-characteristic scores (Confidentiality, Integrity, Availability, Authenticity, Authorization, Non-repudiation).
+
+---
+
+### SupportingAsset
+
+Represents a technical component (server, database, API, device) that stores or processes BusinessAssets.
+
+**Key properties:**
+
+| Property | Type | Description |
+|---|---|---|
+| `supportingAssetId` | `integer \| null` | Auto-incremented at construction |
+| `supportingAssetName` | `string` | Free-text name |
+| `supportingAssetType` | `string` | Enum defined in JSON Schema |
+| `supportingAssetSecurityLevel` | `string` | Security level classification |
+| `businessAssetRef` | `integer[]` | IDs of BusinessAssets that reside on this asset |
+
+---
+
+### Vulnerability
+
+A specific technical weakness. Each vulnerability is scored independently and linked to one or more SupportingAssets.
+
+**Key properties:**
+
+| Property | Type | Description |
+|---|---|---|
+| `vulnerabilityId` | `integer \| null` | Auto-incremented |
+| `vulnerabilityName` | `string` | Free-text name |
+| `vulnerabilityFamily` | `string` | Category enum (e.g. Configuration, Design) |
+| `vulnerabilityTrackingID` | `string` | External defect ID (e.g. GTO ticket) |
+| `vulnerabilityTrackingURI` | `string` | URL to tracking system (validated scheme) |
+| `vulnerabilityDescription` | `string` | HTML rich text |
+| `vulnerabilityDescriptionAttachment` | `string` | Base64-encoded attachment |
+| `vulnerabilityCVE` | `string` | CVSS v2/v3 vector string |
+| `cveScore` | `number \| null` | 0–10 CVSS score |
+| `overallScore` | `integer \| null` | Computed overall vulnerability score |
+| `overallLevel` | `string` | Enum: Low / Medium / High / Critical |
+| `supportingAssetRef` | `Set<integer>` | IDs of SupportingAssets this vulnerability affects |
+
+---
+
+### Risk
+
+A complete threat scenario linking a threat agent + verb to a specific BusinessAsset on a specific SupportingAsset.
+
+**Key properties:**
+
+| Property | Type | Description |
+|---|---|---|
+| `riskId` | `integer \| null` | Auto-incremented via static counter |
+| `riskName` | `string` | Auto-computed or manually overridden |
+| `isAutomaticRiskName` | `boolean` | Whether the name is auto-generated |
+| `threatAgent` | `string` | Enum: type of attacker |
+| `threatAgentDetail` | `string` | HTML detail text |
+| `threatVerb` | `string` | Enum: action taken (disclose, modify, deny, …) |
+| `threatVerbDetail` | `string` | HTML detail text |
+| `motivation` | `string` | Free-text motivation |
+| `motivationDetail` | `string` | HTML detail text |
+| `businessAssetRef` | `integer \| null` | Which BusinessAsset is targeted |
+| `supportingAssetRef` | `integer \| null` | Which SupportingAsset is the attack surface |
+| `riskLikelihood` | `RiskLikelihood` | Likelihood scoring sub-object |
+| `riskImpact` | `RiskImpact` | Impact scoring per characteristic |
+| `allAttackPathsName` | `string` | Combined name of all attack paths (OR) |
+| `allAttackPathsScore` | `number \| null` | Computed worst-case attack path score |
+| `inherentRiskScore` | `number \| null` | Score before mitigations |
+| `mitigationsBenefits` | `number \| null` | Reduction from all accepted/done mitigations |
+| `mitigationsDoneBenefits` | `number \| null` | Reduction from "Done" mitigations only |
+| `mitigatedRiskScore` | `number \| null` | Score after all mitigations |
+| `riskManagementDecision` | `string` | Enum: Accept / Mitigate / Avoid / Transfer |
+| `riskManagementDetail` | `string` | HTML detail text |
+| `residualRiskScore` | `number \| null` | Final residual score |
+| `residualRiskLevel` | `string` | Enum: Low / Medium / High / Critical |
+
+**Child collections on Risk:**
+
+| Map | Purpose |
+|---|---|
+| `#riskAttackPathMap` | Attack paths (AND combinations of Vulnerabilities) |
+| `#riskMitigationMap` | Proposed security controls |
+
+---
+
+### RiskAttackPath
+
+One attack path = one AND-combination of vulnerabilities. Multiple attack paths on the same Risk are combined with OR logic.
+
+Each `RiskAttackPath` holds an array of `vulnerabilityRef` objects (`{ vulnerabilityId, weight }`).
+
+---
+
+### RiskMitigation
+
+A proposed security control for a risk.
+
+**Key properties:** `riskMitigationId`, `riskIdRef`, `description` (HTML), `cost` (integer | null), `decision` (enum), `decisionDetail` (HTML), `mitigationsBenefits` (0–1 double).
+
+---
+
+## Cross-References & Relationships
+
+```
+ISRAProject
+  ├── ISRAProjectContext          (1:1)
+  ├── ISRAMetaTracking[]          (1:N, keyed by trackingIteration)
+  ├── BusinessAsset[]             (1:N, keyed by businessAssetId)
+  │     └── BusinessAssetProperties  (1:1 embedded)
+  ├── SupportingAsset[]           (1:N, keyed by supportingAssetId)
+  │     └── businessAssetRef[]    → references BusinessAsset.businessAssetId
+  ├── Vulnerability[]             (1:N, keyed by vulnerabilityId)
+  │     └── supportingAssetRef[]  → references SupportingAsset.supportingAssetId
+  └── Risk[]                      (1:N, keyed by riskId)
+        ├── businessAssetRef      → references BusinessAsset.businessAssetId
+        ├── supportingAssetRef    → references SupportingAsset.supportingAssetId
+        ├── RiskAttackPath[]      (1:N, keyed by riskAttackPathId)
+        │     └── vulnerabilityRef[] → references Vulnerability.vulnerabilityId
+        ├── RiskLikelihood        (1:1 embedded)
+        ├── RiskImpact            (1:1 embedded)
+        └── RiskMitigation[]      (1:N, keyed by riskMitigationId)
+```
+
+**The reference direction is always downward** — Vulnerability references SupportingAsset, not vice versa. Referential integrity is enforced at save time by the per-tab validators in `request-handlers.js`.
+
+---
+
+## ID Management Pattern
+
+All entity IDs are **monotonically increasing integers** that persist across saves. This means deleting entity #3 does not reuse ID 3 for the next entity.
+
+- **Static counter pattern** (Risk, Vulnerability, BusinessAsset, SupportingAsset): each class holds a private static `#idCount` that auto-increments in `static incrementId()`. On file load, `Class.setIdCount(latestId)` restores the counter to where it left off.
+- **ISRAProject-managed counters** (`#latestBusinessAssetId`, etc.): also persisted in the JSON and used to restore static counters on load.
+- **Map-based re-indexing**: when an item is deleted from a Map (e.g. `RiskAttackPath`), the remaining items are re-indexed sequentially using the `counter()` utility from `utility-global.js` to close gaps.
+
+Example — adding a new BusinessAsset:
+
+```js
+const ba = new BusinessAsset();          // gets next auto-incremented ID
+ba.businessAssetName = 'User Data';
+ba.businessAssetType = 'Data';
+israProject.addBusinessAsset(ba);        // stored in #businessAssetsMap
+```
+
+---
+
+## Operational Notes
+
+- All Maps are converted to plain arrays before serialization using `map2Array()` from `lib/src/model/classes/map2array.js`.
+- `ISRAProject.toJSON()` calls `validateJsonSchema()` before serializing — it will throw if the in-memory state violates the JSON Schema.
+- Never mutate a child object after extracting it from the Map with `getX(id)` without re-setting it — you are working with the live reference, so changes are immediate.
+- `RiskAttackPath` and `RiskMitigation` are nested within `Risk` — they do not have their own top-level Map in `ISRAProject`.
+
+---
+
+## Assumptions Made
+
+- All IDs are positive integers starting from 1. `null` is a valid default for a new unset ID.
+- `BusinessAssetProperties` is always created automatically by `BusinessAsset`'s constructor — it cannot be null.
+- `supportingAssetsDesc` on `ISRAProject` is a free HTML field for attaching an architecture diagram description; it is not a separate class.
+
+## Open Questions
+
+- What are the valid enum values for `businessAssetType`, `supportingAssetType`, `threatAgent`, `threatVerb`, and `overallLevel`? These are defined in `json-schema.js` which was not fully reviewed.
+- Is `ISRAProjectContext` always populated, or can it be empty on a new project?
+
+## Last Reviewed: 2026-06-24

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,166 @@
+# Development Guide
+
+> **Audience:** Newcomers / onboarding developers  
+> **Scope:** Local setup, running the app, testing, linting, and building a distributable.
+
+---
+
+## Purpose & Scope
+
+This guide covers everything a new contributor needs to get the ISRA tool running locally, make changes, verify them through automated tests, and produce a distribution build. It does **not** cover deployment or hosting — ISRA is a fully offline desktop application.
+
+---
+
+## Prerequisites & Setup
+
+| Requirement | Version / Notes |
+|---|---|
+| Node.js | LTS recommended (see `app/package.json` engines if specified) |
+| npm | Bundled with Node.js |
+| Git | Any recent version |
+| Operating System | Windows, macOS, or Linux (Electron supports all three) |
+
+**Clone and install:**
+
+```bash
+# Clone the repository
+git clone <repo-url>
+cd security-risk-assessment-tool
+
+# Install lib dependencies
+cd lib
+npm install
+
+# Install app dependencies
+cd ../app
+npm install
+```
+
+> Both `lib/` and `app/` are independent npm packages. They each have their own `package.json` and `node_modules/`. You must run `npm install` in **both** directories.
+
+The `app/` package references `lib/` directly via a relative `require()` path — no symlinks or `npm link` are needed.
+
+---
+
+## Running the Application
+
+```bash
+# From the repo root
+cd app
+npm start
+```
+
+This launches the Electron application in development mode. The window title will show `ISRA Risk Assessment`. You can open DevTools with `Ctrl+Shift+I` / `Cmd+Option+I`.
+
+**What happens on startup:**
+
+1. `electron/main.js` creates the `BrowserWindow` and loads `tabs/Welcome/welcome.html`.
+2. `main.js` calls `newISRAProject()` via `request-handlers.js`, which initializes a blank `ISRAProject` in memory using `DataNew`.
+3. The renderer receives `project:load` via IPC and populates all tab UIs.
+
+---
+
+## Testing
+
+Tests live in `lib/test/` and are run with Jest 29.
+
+```bash
+# From the repo root
+cd lib
+npm run test
+```
+
+This runs the full test suite **with coverage output**.
+
+**Test structure:**
+
+| Directory | What it tests |
+|---|---|
+| `lib/test/unit/` | Individual classes, schema validation, utility functions |
+| `lib/test/integration/` | Full project load → mutate → save → reload round-trips |
+| `lib/test/integration/fixtures/` | Shared fixture `.sra` / `.json` files used by integration tests |
+| `lib/test/integration/test-N/` | Numbered integration scenarios (test-1 through test-10, etc.) |
+
+**Example: running a single test file:**
+
+```bash
+cd lib
+npx jest test/unit/validation-pattern/validation-pattern.test.js
+```
+
+**Coverage report** is printed to the terminal after each run. No external coverage server is required.
+
+> Tests are scoped to `lib/` only. There are no automated tests for the Electron UI (`app/`). UI behavior can be verified by running the app and exercising the tabs manually.
+
+---
+
+## Linting
+
+ESLint 8 is configured only for `lib/`. There is no ESLint setup in `app/`.
+
+```bash
+# From the repo root
+cd lib
+npx eslint src/
+```
+
+Configuration file: `lib/.eslintrc.json`.
+
+**Common rules to be aware of:**
+- No unused variables
+- Consistent `require()` ordering
+- The linter does **not** run as a pre-commit hook by default — run it manually before opening a PR
+
+---
+
+## Building a Distributable
+
+```bash
+# From the repo root
+cd app
+npm run dist
+```
+
+This uses **electron-builder** to produce a platform-native installer (`.exe` on Windows, `.dmg` on macOS, `.AppImage` / `.deb` on Linux). The output is placed in `app/dist/`.
+
+**Notes:**
+- The build bundles `lib/` as a local dependency — no npm publish step is needed.
+- Code signing configuration (if required) is set in `app/package.json` under the `build` key.
+- The distributable is fully self-contained and offline — no internet access is required at runtime.
+
+---
+
+## Generating JSDoc
+
+```bash
+cd lib
+npm run jsdoc
+```
+
+This generates HTML documentation from JSDoc comments in `lib/src/`. Output location is determined by the `jsdoc.json` config in `lib/`.
+
+---
+
+## Operational Notes
+
+- **Adding a new npm dependency to `lib`:** Run `npm install <pkg>` inside `lib/`. Make sure to also add it to `lib/package.json`. Since `app/` uses `lib/` via relative path, the dependency will be available automatically.
+- **Adding a new npm dependency to `app`:** Run `npm install <pkg>` inside `app/`.
+- **Environment variables:** None. All configuration is in `lib/src/config.js` — edit that file directly for defaults.
+- **Node version compatibility:** Use the same Node.js version that Electron bundles internally for `lib/` code, to avoid subtle compatibility issues.
+- **Windows path notes:** Some `npm` scripts may use Unix-style paths. If you encounter issues on Windows, check the `scripts` section of `lib/package.json`.
+
+---
+
+## Assumptions Made
+
+- Node.js LTS is already installed and available on `PATH`.
+- Both `lib/` and `app/` `node_modules/` are installed before running any command.
+- There are no pre-commit hooks or CI/CD pipelines described in the reviewed files — these may exist outside the scanned scope.
+
+## Open Questions
+
+- Is there a `.nvmrc` or `engines` field specifying the exact required Node.js version?
+- Are there any CI pipelines (GitHub Actions, etc.) that automate test and lint on push?
+- Is code signing configured for the distributable build?
+
+## Last Reviewed: 2026-06-24

--- a/docs/docgen/tasks.json
+++ b/docs/docgen/tasks.json
@@ -1,0 +1,276 @@
+{
+  "config": {
+    "overwrite_strategy": "Ask"
+  },
+  "topic": {
+    "title": "ISRA — Security Risk Assessment Tool",
+    "path": "docs"
+  },
+  "outline": [
+    {
+      "title": "Architecture Overview",
+      "purpose": "Explain the monorepo structure, Electron + lib separation, and high-level component responsibilities.",
+      "reader_outcomes": "Newcomer understands why the project is split into lib/ and app/, how they relate, and where to add new logic."
+    },
+    {
+      "title": "Data Model",
+      "purpose": "Document every domain class, their properties, relationships, and lifecycle (add/delete/get patterns).",
+      "reader_outcomes": "Developer knows which class to modify for a given data change and understands cross-references between entities."
+    },
+    {
+      "title": "Development Guide",
+      "purpose": "Onboarding guide covering setup, running the app, tests, linting, and building a distributable.",
+      "reader_outcomes": "New contributor can run, test, and lint the project without asking for help."
+    },
+    {
+      "title": "Risk Assessment Workflow",
+      "purpose": "Walk through the ISO 27005 process: project context → business assets → supporting assets → vulnerabilities → risks → mitigation.",
+      "reader_outcomes": "Understand the sequential workflow, what each step produces, and how entities link to each other."
+    },
+    {
+      "title": "File Format & I/O",
+      "purpose": "Document the .sra file format (JSON), legacy XML migration pipeline, and data-load/data-store API.",
+      "reader_outcomes": "Developer understands how projects are persisted, loaded, and migrated from older XML-based InfoPath files."
+    },
+    {
+      "title": "IPC Architecture",
+      "purpose": "Document the full Electron IPC chain from renderer → contextBridge → ipcRenderer → ipcMain → lib API.",
+      "reader_outcomes": "Developer knows how to add a new IPC channel safely and correctly."
+    },
+    {
+      "title": "Validation Pattern",
+      "purpose": "Explain the AJV-based validation approach, JSON Schema, validateClassProperties helper, and per-tab validation in the app.",
+      "reader_outcomes": "Developer knows how to add a new validated field end-to-end."
+    },
+    {
+      "title": "Electron Security",
+      "purpose": "Document Electron security configuration: nodeIntegration, contextIsolation, URL scheme whitelist, and rich-text sanitization.",
+      "reader_outcomes": "Developer knows which security constraints must not be relaxed and why."
+    }
+  ],
+  "tasks": [
+    {
+      "id": "architecture-overview",
+      "title": "Architecture Overview",
+      "intent": "architecture",
+      "write": {
+        "mode": "write_file",
+        "destination": "docs/architecture-overview.md",
+        "subheading": "Architecture Overview"
+      },
+      "audience": "newcomers",
+      "depth": {
+        "min_words": 700,
+        "min_tables": 1,
+        "require_diagram": true,
+        "min_examples": 1
+      },
+      "required_sections": [
+        "Purpose & Scope",
+        "Monorepo Structure",
+        "Key Components & Responsibilities",
+        "Technology Stack",
+        "Operational Notes"
+      ],
+      "use_jsdoc": true
+    },
+    {
+      "id": "data-model",
+      "title": "Data Model",
+      "intent": "data-models",
+      "write": {
+        "mode": "write_file",
+        "destination": "docs/data-model.md",
+        "subheading": "Data Model"
+      },
+      "audience": "newcomers",
+      "depth": {
+        "min_words": 800,
+        "min_tables": 2,
+        "require_diagram": true,
+        "min_examples": 2
+      },
+      "required_sections": [
+        "Purpose & Scope",
+        "Domain Entity Overview",
+        "Class Details",
+        "Cross-References & Relationships",
+        "ID Management Pattern",
+        "Operational Notes"
+      ],
+      "use_jsdoc": true
+    },
+    {
+      "id": "development",
+      "title": "Development Guide",
+      "intent": "development",
+      "write": {
+        "mode": "write_file",
+        "destination": "docs/development.md",
+        "subheading": "Development Guide"
+      },
+      "audience": "newcomers",
+      "depth": {
+        "min_words": 600,
+        "min_tables": 1,
+        "require_diagram": false,
+        "min_examples": 2
+      },
+      "required_sections": [
+        "Purpose & Scope",
+        "Prerequisites & Setup",
+        "Running the Application",
+        "Testing",
+        "Linting",
+        "Building a Distributable",
+        "Operational Notes"
+      ],
+      "use_jsdoc": false
+    },
+    {
+      "id": "risk-assessment-workflow",
+      "title": "Risk Assessment Workflow",
+      "intent": "domain-workflows",
+      "write": {
+        "mode": "write_file",
+        "destination": "docs/features/risk-assessment-workflow.md",
+        "subheading": "Risk Assessment Workflow"
+      },
+      "audience": "newcomers",
+      "depth": {
+        "min_words": 700,
+        "min_tables": 1,
+        "require_diagram": true,
+        "min_examples": 1
+      },
+      "required_sections": [
+        "Purpose & Scope",
+        "When to Use / When Not to Use",
+        "Workflow Steps (ISO 27005)",
+        "Key Entities & Their Roles",
+        "Risk Scoring & Mitigation",
+        "Operational Notes"
+      ],
+      "use_jsdoc": true
+    },
+    {
+      "id": "file-format-and-io",
+      "title": "File Format & I/O",
+      "intent": "configuration-policies",
+      "write": {
+        "mode": "write_file",
+        "destination": "docs/features/file-format-and-io.md",
+        "subheading": "File Format & I/O"
+      },
+      "audience": "newcomers",
+      "depth": {
+        "min_words": 600,
+        "min_tables": 1,
+        "require_diagram": false,
+        "min_examples": 1
+      },
+      "required_sections": [
+        "Purpose & Scope",
+        "The .sra File Format",
+        "Opening a File (DataLoad)",
+        "Saving a File (DataStore)",
+        "XML to JSON Migration Pipeline",
+        "Schema Version Handling",
+        "Operational Notes"
+      ],
+      "use_jsdoc": true
+    },
+    {
+      "id": "ipc-architecture",
+      "title": "IPC Architecture",
+      "intent": "architecture",
+      "write": {
+        "mode": "write_file",
+        "destination": "docs/features/ipc-architecture.md",
+        "subheading": "IPC Architecture"
+      },
+      "audience": "newcomers",
+      "depth": {
+        "min_words": 600,
+        "min_tables": 2,
+        "require_diagram": false,
+        "min_examples": 1
+      },
+      "required_sections": [
+        "Purpose & Scope",
+        "When to Use / When Not to Use",
+        "IPC Channel Reference",
+        "Adding a New IPC Channel",
+        "Security Constraints",
+        "Operational Notes"
+      ],
+      "use_jsdoc": true
+    },
+    {
+      "id": "validation-pattern",
+      "title": "Validation Pattern",
+      "intent": "authentication-security",
+      "write": {
+        "mode": "write_file",
+        "destination": "docs/features/validation-pattern.md",
+        "subheading": "Validation Pattern"
+      },
+      "audience": "newcomers",
+      "depth": {
+        "min_words": 550,
+        "min_tables": 1,
+        "require_diagram": false,
+        "min_examples": 2
+      },
+      "required_sections": [
+        "Purpose & Scope",
+        "AJV Instance & JSON Schema",
+        "Adding a New Validated Field",
+        "Per-Tab Validation in the App",
+        "Error Message Format",
+        "Operational Notes"
+      ],
+      "use_jsdoc": true
+    },
+    {
+      "id": "electron-security",
+      "title": "Electron Security",
+      "intent": "authentication-security",
+      "write": {
+        "mode": "write_file",
+        "destination": "docs/features/electron-security.md",
+        "subheading": "Electron Security"
+      },
+      "audience": "newcomers",
+      "depth": {
+        "min_words": 500,
+        "min_tables": 1,
+        "require_diagram": false,
+        "min_examples": 1
+      },
+      "required_sections": [
+        "Purpose & Scope",
+        "Core Security Settings",
+        "URL Scheme Whitelist",
+        "Rich-Text Sanitization",
+        "What Must Never Change",
+        "Operational Notes"
+      ],
+      "use_jsdoc": false
+    }
+  ],
+  "links": {
+    "openapi": []
+  },
+  "assumptions": [
+    "No HTTP server endpoints exist — this is a fully offline Electron desktop app. OpenAPI generation is skipped.",
+    "Audience is newcomers / onboarding developers.",
+    "Config defaults (appVersion: 1.3.0-alpha01, organizations list) are sourced from lib/src/config.js.",
+    "Schema version cap of 3 is based on getJSON() guard in request-handlers.js."
+  ],
+  "open_questions": [
+    "What is the full list of supported schemaVersion values and their migration differences?",
+    "Is there a planned migration path beyond schemaVersion 3?",
+    "Are there plans to add HTTP endpoints or a server mode in future versions?"
+  ]
+}

--- a/docs/features/electron-security.md
+++ b/docs/features/electron-security.md
@@ -1,0 +1,111 @@
+# Electron Security
+
+> **Audience:** Newcomers / onboarding developers  
+> **Scope:** Security configuration of the Electron shell — which settings must never change and why, URL scheme constraints, and rich-text sanitization.
+
+---
+
+## Purpose & Scope
+
+Electron applications run Chromium (renderer) + Node.js (main) in the same process tree. Misconfigured Electron apps can expose the host OS to attacks from malicious content rendered in the browser window. ISRA applies a strict security configuration that must be preserved as the application evolves.
+
+This document describes each security setting, explains why it exists, and lists what must never be relaxed.
+
+---
+
+## Core Security Settings
+
+These settings are configured in `app/src/electron/main.js` when creating the `BrowserWindow`:
+
+| Setting | Value | Why |
+|---|---|---|
+| `nodeIntegration` | `false` | Prevents renderer JS from calling `require()` and accessing Node.js APIs directly. A compromised renderer cannot read the filesystem or execute child processes. |
+| `contextIsolation` | `true` | The preload script runs in a separate JavaScript context. `window` in preload ≠ `window` in the page — attackers cannot overwrite preload globals from page scripts. |
+| `preload` | `path.join(__dirname, './preload.js')` | Only the explicitly listed `contextBridge` APIs are accessible to the renderer. No other Node APIs leak through. |
+
+These three settings work together as a defence-in-depth stack. Disabling any one of them breaks the security model:
+
+- Disabling `contextIsolation` alone allows renderer scripts to prototype-pollute preload globals.
+- Disabling `nodeIntegration` alone (with `contextIsolation: false`) still leaves prototype-pollution vectors.
+- Both must remain enabled together.
+
+---
+
+## URL Scheme Whitelist
+
+Vulnerability tracking URIs (the `vulnerabilityTrackingURI` field on `Vulnerability`) accept only a restricted set of URL schemes to prevent `javascript:`, `file:`, or other dangerous schemes from being stored and later opened.
+
+**Allowed schemes** (verified from `CLAUDE.md` and validation layer):
+
+| Scheme | Use case |
+|---|---|
+| `ftp` | Legacy FTP-based tracking systems |
+| `http` | Internal tracking tools |
+| `https` | Standard web-based defect trackers |
+| `mailto` | Email references |
+| `tel` | Phone number references |
+| `urn` | Uniform Resource Names |
+
+Any URI that does not start with one of these schemes is rejected by the `isVulnerabilityTrackingURI` validator in `lib/src/model/classes/Vulnerability/validation.js`.
+
+The same scheme restriction applies to URLs opened via `utility:openURL`, `vulnerabilities:openURL`, and `projectContext:openURL` IPC channels — these channels call `shell.openExternal()` in the main process, which opens URLs in the system browser. Passing a `javascript:` or `file:` URI here would execute code or expose local files.
+
+---
+
+## Rich-Text Sanitization
+
+Several fields accept HTML rich text edited via TinyMCE:
+
+- `businessAssetDescription`
+- `supportingAssetsDesc`
+- `vulnerabilityDescription`
+- `threatAgentDetail`, `threatVerbDetail`, `motivationDetail`, `riskManagementDetail`
+- `ISRAProjectContext` scope / assumption fields
+
+TinyMCE output is sanitized before being persisted. The sanitization logic lives in `lib/src/api/xml-json/` (the `utility.js` file in that directory). Sanitization removes:
+
+- `<script>` tags and `javascript:` event attributes
+- Inline event handlers (`onerror`, `onclick`, etc.)
+- Potentially dangerous iframe or object embeds
+
+This prevents stored XSS: if a project file is shared and opened by another user, malicious HTML stored in description fields cannot execute in the renderer.
+
+---
+
+## What Must Never Change
+
+The following constraints are **non-negotiable** and must not be relaxed in any future development:
+
+| Constraint | Risk if relaxed |
+|---|---|
+| `nodeIntegration: false` | Renderer gains full Node.js access — RCE from any XSS |
+| `contextIsolation: true` | Preload APIs become prototype-pollution targets |
+| URL scheme whitelist | `javascript:` or `file:` URIs could execute code or exfiltrate files |
+| Sanitize all TinyMCE output before persistence | Stored XSS persists across sessions and users |
+| Never expose `ipcRenderer` directly on `window` | Bypasses the contextBridge whitelist entirely |
+| All new IPC channels must be added to the whitelist in `preload.js` | Unlisted channels are silently dropped — but if the whitelist logic is bypassed, arbitrary channels become accessible |
+
+---
+
+## Operational Notes
+
+- When adding a new rich-text field, ensure TinyMCE output passes through the sanitization utility before being assigned to the model property.
+- When adding a new URL field, add the same scheme validation (`isVulnerabilityTrackingURI` or equivalent) before accepting user input.
+- The Import dialog (`tabs/Import/`) opens a separate `BrowserWindow` with `modal: true` and the same `preload.js` — it inherits the same security settings.
+- The PDF report generation creates an invisible `BrowserWindow` (`show: false`) — this window also uses `preload.js` and must not relax security settings just because it is hidden.
+- There are no Content Security Policy headers currently configured for the local `file://` pages — this is an open area for improvement (see Open Questions).
+
+---
+
+## Assumptions Made
+
+- `nodeIntegration: false` and `contextIsolation: true` are set in `main.js` based on the CLAUDE.md security notes and the preload architecture. The exact `webPreferences` object was not read from `main.js` directly.
+- TinyMCE sanitization is applied in `lib/src/api/xml-json/utility.js` — the specific sanitization approach (allowlist vs denylist) was not fully reviewed.
+
+## Open Questions
+
+- Is a Content Security Policy (CSP) configured for the `file://` renderer pages? If not, is there a plan to add one?
+- Does the sanitization use an allowlist of safe tags, or a denylist of dangerous tags? Allowlist is safer.
+- Is `webSecurity` explicitly set to `true` (the default) or has it been disabled anywhere for development convenience?
+
+## Last Reviewed: 2026-06-24

--- a/docs/features/file-format-and-io.md
+++ b/docs/features/file-format-and-io.md
@@ -1,0 +1,169 @@
+# File Format & I/O
+
+> **Audience:** Newcomers / onboarding developers  
+> **Scope:** The `.sra` project file format, how files are opened and saved via the `lib` API, and how legacy XML files are migrated.
+
+---
+
+## Purpose & Scope
+
+ISRA projects are stored as plain JSON files with the `.sra` extension. All file I/O is handled exclusively through the `lib/src/api/` module — the Electron app never reads or writes files directly. This document explains the file structure, the four API entry points (`DataNew`, `DataLoad`, `DataStore`, `XML2JSON`), and the XML migration pipeline for legacy InfoPath-based assessments.
+
+---
+
+## The .sra File Format
+
+An `.sra` file is a **UTF-8 encoded JSON file** pretty-printed with 4-space indentation. It is the serialized form of an `ISRAProject` instance.
+
+**Top-level structure:**
+
+```json
+{
+  "ISRAmeta": {
+    "appVersion": "1.3.0-alpha01",
+    "schemaVersion": 3,
+    "classification": "COMPANY CONFIDENTIAL {MyProject}",
+    "iteration": 2,
+    "projectName": "MyProject",
+    "projectOrganization": "Engineering department",
+    "projectVersion": "1.0",
+    "ISRAtracking": [ ... ],
+    "businessAssetsCount": 2,
+    "supportingAssetsCount": 1,
+    "risksCount": 1,
+    "vulnerabilitiesCount": 1,
+    "latestBusinessAssetId": 2,
+    "latestSupportingAssetId": 1,
+    "latestRiskId": 1,
+    "latestVulnerabilityId": 1
+  },
+  "ProjectContext": { ... },
+  "BusinessAsset": [ ... ],
+  "SupportingAssetsDesc": "<p>Architecture diagram...</p>",
+  "SupportingAsset": [ ... ],
+  "Risk": [ ... ],
+  "Vulnerability": [ ... ]
+}
+```
+
+**Key design decisions:**
+- All child entity Maps are serialized as **arrays** (using `map2Array()`).
+- IDs are monotonically increasing and are **persisted** in `ISRAmeta` (`latestBusinessAssetId`, etc.) so that counters can be restored correctly on reload — deleting entity #3 never re-uses ID 3.
+- Rich-text fields (descriptions, details) are stored as **raw HTML strings** produced by TinyMCE.
+- File attachments (e.g. vulnerability documents) are stored as **base64-encoded strings**.
+- The `schemaVersion` field gates backwards-compatibility — files with `schemaVersion > 3` are rejected.
+
+---
+
+## Opening a File (DataLoad)
+
+`DataLoad` handles `.sra` and `.json` files. It is exported from `lib/src/api/data-load/index.js`.
+
+**Call site (in `request-handlers.js`):**
+
+```js
+const { DataLoad } = require('../../../lib/src/api/index');
+israProject = DataLoad(filePath);  // returns a populated ISRAProject instance
+```
+
+**What DataLoad does:**
+1. Reads the file from disk with `fs.readFileSync`.
+2. Parses the JSON.
+3. Handles legacy format migration (files without `schemaVersion` field — see Schema Version Handling below).
+4. Normalizes `ISRAtracking` dates to `YYYY-MM-DD` format.
+5. Calls `validateJsonSchema()` to validate the parsed JSON against the AJV schema.
+6. Calls `populateClass()` to reconstruct the full class hierarchy from the plain JSON.
+7. Returns a live `ISRAProject` instance.
+
+If any step fails, an error is thrown and `request-handlers.js` shows a dialog with the error message.
+
+---
+
+## Saving a File (DataStore)
+
+`DataStore` is exported from `lib/src/api/data-store/index.js`.
+
+**Call site:**
+
+```js
+const { DataStore } = require('../../../lib/src/api/index');
+await DataStore(israProject, filePath);
+```
+
+**What DataStore does:**
+1. Calls `israProject.toJSON()` — which internally calls `validateJsonSchema()` and then `JSON.stringify(…, null, 4)`.
+2. Writes the resulting JSON string to `filePath` using `fs.writeFile`.
+
+**Two save modes in the app:**
+
+| Mode | When triggered | Behaviour |
+|---|---|---|
+| **Save** | File already has a path (`jsonFilePath !== ''`) | Overwrites the existing `.sra` file at `jsonFilePath` |
+| **Save As** | First save or user chooses "Save As" | Opens a native file picker; writes to the selected path |
+
+Before saving, the app checks for unsaved changes (`israProject.toJSON() !== oldIsraProject`). If changes exist, `iteration` is incremented and a new `ISRAtracking` entry is expected.
+
+---
+
+## XML to JSON Migration Pipeline
+
+Legacy ISRA assessments were created in Microsoft InfoPath as `.xml` files. The `XML2JSON` pipeline converts them to the current JSON format.
+
+**Call site:**
+
+```js
+const { XML2JSON } = require('../../../lib/src/api/index');
+israProject = XML2JSON(filePath);  // reads .xml, returns ISRAProject
+```
+
+**Pipeline stages (`lib/src/api/xml-json/`):**
+
+| Stage | File | Purpose |
+|---|---|---|
+| 1. Parse | `parser.js` | Uses `xml2js` to convert raw XML to a JavaScript object |
+| 2. Alter | `alter-isra/alter-isra.js` | Transforms the InfoPath-specific structure into the canonical JSON shape |
+| 3. Validate | `validate-json-schema.js` | Validates the transformed JSON against the AJV schema |
+| 4. Populate | `populate-class.js` | Constructs the full `ISRAProject` class hierarchy |
+
+The `alter-isra/` directory contains transformation helpers that handle structural differences between the InfoPath XML schema and the current JSON schema, including field renaming, type coercions, and missing-field defaults.
+
+After a successful XML import, the file is treated as "unsaved" (`jsonFilePath = ''`), so the user must Save As to a new `.sra` file — the original `.xml` is never modified.
+
+---
+
+## Schema Version Handling
+
+The `schemaVersion` field in `ISRAmeta` is a forward-compatibility guard.
+
+| Condition | Behaviour |
+|---|---|
+| `schemaVersion` field absent | Legacy format — applies a structural migration (removes nested `riskName` object, fixes `vulnerabilityRef` references) |
+| `schemaVersion <= 3` | Accepted and loaded normally |
+| `schemaVersion > 3` | **Rejected** — throws `Unable to load schema version N, this version only supports 3 and below` |
+
+The migration for schema-less files (in `request-handlers.js getJSON()`) flattens the old `riskName` object and maps `vulnerabilityRef` by name-to-ID lookup.
+
+---
+
+## Operational Notes
+
+- **Never call `fs` directly from `app/`** — all file I/O goes through `lib/src/api/`. This keeps the business logic testable and isolated from Electron.
+- **Supported file extensions at the open dialog:** `.sra`, `.json` (JSON format), `.xml` (InfoPath XML).
+- **The `.sra` extension** is just a naming convention; the file content is standard JSON. You can open an `.sra` file in any text editor.
+- **Import vs Open:** The app has two distinct flows — "Open" (replaces the current project) and "Import" (merges selected data from another project into the current one via a modal dialog). Import uses the same parsing pipeline but routes through `import:sendImports` IPC channel.
+- **File encoding:** Always UTF-8. No BOM.
+
+---
+
+## Assumptions Made
+
+- `populateClass()` in `lib/src/api/xml-json/populate-class.js` reconstructs all Maps and restores static ID counters on all entity classes.
+- The `DataNew` API (`lib/src/api/data-new/index.js`) initializes the `ISRAProject` with default values from the JSON Schema but does not write any file until the user explicitly saves.
+
+## Open Questions
+
+- What fields does `DataNew` pre-populate beyond the JSON Schema defaults?
+- Does the Import dialog support merging all entity types (BusinessAssets, Risks, Vulnerabilities) or only a subset?
+- Are there migration scripts for moving from schemaVersion 1 or 2 to 3?
+
+## Last Reviewed: 2026-06-24

--- a/docs/features/ipc-architecture.md
+++ b/docs/features/ipc-architecture.md
@@ -1,0 +1,232 @@
+# IPC Architecture
+
+> **Audience:** Newcomers / onboarding developers  
+> **Scope:** How the Electron renderer process communicates with the main process — the full IPC channel inventory and how to add a new channel safely.
+
+---
+
+## Purpose & Scope
+
+Electron runs two separate JavaScript environments: the **renderer process** (Chromium, handles the DOM) and the **main process** (Node.js, has file system / OS access). These two environments cannot share memory. All communication goes through **Inter-Process Communication (IPC)** via a strictly whitelisted bridge defined in `preload.js`.
+
+This document explains why this architecture exists, documents every exposed channel, and walks through the steps needed to add a new one.
+
+---
+
+## When to Use / When Not to Use
+
+| ✅ Use IPC for… | ❌ Never do this… |
+|---|---|
+| Reading / writing project data (render:*, validate:*) | Call `require()` on Node.js or `lib` modules from renderer JS |
+| Triggering file dialogs (open, save, save as) | Expose `ipcRenderer` directly to the renderer via `window` |
+| Fetching config options (welcome:getConfig) | Add a channel that is not in the `validChannels` whitelist |
+| Sending mutations (businessAssets:updateBusinessAsset) | Pass raw file paths or secrets through IPC messages |
+
+---
+
+## IPC Channel Reference
+
+All channels are declared in `app/src/electron/preload.js`. They are organized into namespace groups by the `contextBridge.exposeInMainWorld()` call that exposes them.
+
+### `window.project` — Project lifecycle events (renderer ← main)
+
+| Channel | Direction | Description |
+|---|---|---|
+| `project:load` | main → renderer | Sends the full `ISRAProject.toJSON()` JSON string to all tabs on load |
+| `project:iteration` | main → renderer | Notifies renderer of new iteration count after a save |
+
+### `window.render` — Read data (renderer → main, returns data)
+
+All `render:*` channels use `ipcRenderer.invoke` (promise-based, returns a value).
+
+| Channel | Returns | Description |
+|---|---|---|
+| `render:welcome` | JSON | ISRAmeta + ISRAtracking data |
+| `render:projectContext` | JSON | ISRAProjectContext data |
+| `render:businessAssets` | JSON | Array of BusinessAsset objects |
+| `render:supportingAssets` | JSON | Array of SupportingAsset objects + SupportingAssetsDesc |
+| `render:risks` | JSON | Array of Risk objects |
+| `render:vulnerabilities` | JSON | Array of Vulnerability objects |
+
+### `window.validate` — Write mutations (renderer → main)
+
+`send` channels fire-and-forget; `invoke` channels return a result (e.g. updated entity).
+
+| Channel | Type | Description |
+|---|---|---|
+| `validate:welcome` | send | Update project-level fields (name, version, organization, classification) |
+| `validate:projectContext` | send | Update ISRAProjectContext fields |
+| `validate:businessAssets` | send | Bulk update BusinessAsset fields |
+| `validate:supportingAssets` | send | Bulk update SupportingAsset fields + desc |
+| `validate:vulnerabilities` | invoke | Update Vulnerability fields; returns updated data |
+| `validate:risks` | invoke | Update Risk fields; returns updated data |
+| `validate:allTabs` | on (listener) | Triggers full validation + save flow from main |
+
+### `window.welcome` — Welcome tab actions
+
+| Channel | Type | Description |
+|---|---|---|
+| `welcome:addTrackingRow` | invoke | Adds a new ISRAMetaTracking entry |
+| `welcome:deleteTrackingRow` | invoke | Deletes tracking rows by iteration numbers |
+| `welcome:updateTrackingRow` | send | Updates a single tracking row's fields |
+| `welcome:updateProjectNameAndVersionRef` | send | Updates projectName or projectVersion across all referencing entities |
+| `welcome:getConfig` | invoke | Returns the organizations list from `config.js` |
+| `welcome:updateConfigOrg` | invoke | Updates the organizations list in config |
+
+### `window.businessAssets` — Business Asset CRUD
+
+| Channel | Type | Description |
+|---|---|---|
+| `businessAssets:addBusinessAsset` | invoke | Creates a new BusinessAsset; returns the new entity |
+| `businessAssets:deleteBusinessAsset` | send | Deletes BusinessAsset(s) by ID array |
+| `businessAssets:updateBusinessAsset` | send | Updates a single field on a BusinessAsset |
+
+### `window.supportingAssets` — Supporting Asset CRUD
+
+| Channel | Type | Description |
+|---|---|---|
+| `supportingAssets:addSupportingAsset` | invoke | Creates a new SupportingAsset |
+| `supportingAssets:deleteSupportingAsset` | send | Deletes SupportingAsset(s) by ID array |
+| `supportingAssets:updateSupportingAsset` | send | Updates a single field |
+| `supportingAssets:addBusinessAssetRef` | send | Adds a Business Asset reference to a Supporting Asset |
+| `supportingAssets:deleteBusinessAssetRef` | send | Removes Business Asset reference(s) |
+| `supportingAssets:updateBusinessAssetRef` | invoke | Updates a Business Asset reference at a given index |
+
+### `window.risks` — Risk CRUD
+
+| Channel | Type | Description |
+|---|---|---|
+| `risks:addRisk` | invoke | Creates a new Risk |
+| `risks:deleteRisk` | send | Deletes Risk(s) by ID array |
+| `risks:updateRiskName` | invoke | Updates the risk name or isAutomaticRiskName flag |
+| `risks:updateRiskLikelihood` | invoke | Updates a RiskLikelihood field |
+| `risks:updateRiskImpact` | invoke | Updates a RiskImpact field |
+| `risks:addRiskAttackPath` | invoke | Adds a RiskAttackPath to a Risk |
+| `risks:deleteRiskAttackPath` | invoke | Deletes RiskAttackPath(s) |
+| `risks:updateRiskAttackPath` | invoke | Updates a field on a RiskAttackPath row |
+| `risks:addRiskVulnerabilityRef` | invoke | Adds a Vulnerability reference to an attack path |
+| `risks:deleteRiskVulnerabilityRef` | invoke | Removes Vulnerability reference(s) from an attack path |
+| `risks:addRiskMitigation` | invoke | Adds a RiskMitigation to a Risk |
+| `risks:deleteRiskMitigation` | invoke | Deletes RiskMitigation(s) |
+| `risks:updateRiskMitigation` | invoke | Updates a field on a RiskMitigation |
+| `risks:updateRiskManagement` | invoke | Updates management decision / residual fields |
+| `risks:isRiskExist` | invoke | Returns boolean — whether a riskId exists |
+| `risks:expectedBenefitsOptions` | invoke | Returns enum options for expected benefits |
+| `risks:mitigationDecisionOptions` | invoke | Returns enum options for mitigation decision |
+
+### `window.vulnerabilities` — Vulnerability CRUD
+
+| Channel | Type | Description |
+|---|---|---|
+| `vulnerabilities:addVulnerability` | invoke | Creates a new Vulnerability |
+| `vulnerabilities:deleteVulnerability` | send | Deletes Vulnerability(ies) by ID array |
+| `vulnerabilities:updateVulnerability` | invoke | Updates a single field |
+| `vulnerabilities:urlPrompt` | invoke | Opens a URL input dialog; returns the entered URL |
+| `vulnerabilities:openURL` | send | Opens a URL in the system browser |
+| `vulnerabilities:attachment` | send | Opens file picker for a vulnerability attachment |
+| `vulnerabilities:decodeAttachment` | invoke | Decodes a base64 attachment; returns file content |
+| `vulnerabilities:fileName` | on (listener) | Receives the filename of an attachment from main |
+| `vulnerabilities:isVulnerabilityExist` | invoke | Returns boolean — whether a vulnerabilityId exists |
+
+### `window.projectContext` — Project Context tab
+
+| Channel | Type | Description |
+|---|---|---|
+| `projectContext:openURL` | send | Opens a URL in the system browser |
+| `projectContext:urlPrompt` | invoke | Opens a URL input dialog |
+| `projectContext:attachment` | send | Opens file picker for a context attachment |
+| `projectContext:decodeAttachment` | invoke | Decodes a base64 attachment |
+| `projectContext:fileName` | on (listener) | Receives filename from main |
+
+### `window.import` / `window.api` — Import dialog
+
+| Channel | Type | Description |
+|---|---|---|
+| `import:sendImports` | send | Sends import data from the import dialog to main |
+| `import:submit` | send | (via window.api) Submits the import selection |
+| `import:load` | on (via window.api) | Receives parsed import data in the dialog |
+
+### `window.israreport` — PDF Report
+
+| Channel | Type | Description |
+|---|---|---|
+| `israreport:saveGraph` | send | Sends a chart/graph image from the report tab to main |
+| `israreport:fetchedContent` | send | Signals that the report tab has finished loading data (triggers PDF generation) |
+
+### `window.utility`
+
+| Channel | Type | Description |
+|---|---|---|
+| `utility:openURL` | send | Opens a URL in the default system browser |
+
+---
+
+## Adding a New IPC Channel
+
+Follow these four steps — each is a **Baby Step™** that must be validated before the next.
+
+**Step 1 — Decide the communication pattern:**
+- Use `ipcRenderer.invoke` / `ipcMain.handle` if the renderer needs a return value (e.g. "give me the updated Risk object").
+- Use `ipcRenderer.send` / `ipcMain.on` if it is fire-and-forget (e.g. "delete this asset").
+- Use `ipcRenderer.on` / `win.webContents.send` if main needs to push data to the renderer.
+
+**Step 2 — Add the channel to `preload.js`:**
+
+```js
+// app/src/electron/preload.js
+contextBridge.exposeInMainWorld('myFeature', {
+  doSomething: (id, value) => ipcRenderer.invoke('myFeature:doSomething', id, value),
+});
+```
+
+If you use `api.send` / `api.receive`, add the new channel name to the `validChannels` whitelist inside those methods.
+
+**Step 3 — Add the `ipcMain` handler in `request-handlers.js`:**
+
+```js
+// app/src/electron/request-handlers.js
+ipcMain.handle('myFeature:doSomething', async (event, id, value) => {
+  // Call lib API — e.g. israProject.getMyEntity(id).someField = value;
+  return israProject.getMyEntity(id).properties;  // return plain object, not class instance
+});
+```
+
+**Step 4 — Call from the renderer tab:**
+
+```js
+// app/src/tabs/MyFeature/my-feature.js
+const result = await window.myFeature.doSomething(id, value);
+```
+
+> ⚠️ Never pass a class instance (e.g. `ISRAProject`) through IPC. Always serialize to a plain object or JSON string first.
+
+---
+
+## Security Constraints
+
+- `nodeIntegration` is **disabled** — renderer scripts cannot call `require()`.
+- `contextIsolation` is **enabled** — the preload script runs in an isolated context; `window` in preload ≠ `window` in renderer.
+- Only channels explicitly listed in `preload.js` are reachable from the renderer. Any attempt to call an unlisted channel is silently dropped.
+- File paths are never passed from renderer to main as user-controlled input. File dialogs are opened by `ipcMain` handlers, which return a path; the renderer never supplies a raw path.
+
+---
+
+## Operational Notes
+
+- All `ipcMain.handle` handlers in `request-handlers.js` operate on the shared `israProject` variable, which is the single live `ISRAProject` instance for the current session.
+- If a handler mutates `israProject`, the updated state is not automatically pushed to the renderer — the caller must re-fetch via the appropriate `render:*` channel or use the return value.
+- The `validate:allTabs` flow is the save trigger: renderer → main triggers validation → if valid, calls `saveProject()`.
+
+---
+
+## Assumptions Made
+
+- The `validChannels` arrays in `window.api.send` and `window.api.receive` are maintained manually — they are not auto-generated from the handler registrations.
+- There is no IPC channel versioning or middleware — all channels are flat strings.
+
+## Open Questions
+
+- Are there any `ipcMain.on` handlers registered outside of `request-handlers.js` (e.g. in `main.js`)?
+- Is there a plan to migrate from `ipcRenderer.send` (fire-and-forget) to `ipcRenderer.invoke` (promise-based) for consistency?
+
+## Last Reviewed: 2026-06-24

--- a/docs/features/risk-assessment-workflow.md
+++ b/docs/features/risk-assessment-workflow.md
@@ -1,0 +1,229 @@
+# Risk Assessment Workflow
+
+> **Audience:** Newcomers / onboarding developers  
+> **Scope:** The ISO 27005 risk assessment process as implemented in ISRA — from project setup through to risk treatment decisions.
+
+---
+
+## Purpose & Scope
+
+ISRA guides a security engineer through a structured, iterative risk assessment following **ISO/IEC 27005**. The tool captures the assessment as a project file (`.sra`) that passes through six sequential phases. Each phase builds on data entered in the previous one — skipping phases or leaving required fields empty triggers validation warnings at save time.
+
+This document explains what each phase produces, which domain classes are involved, and how the data flows from one phase to the next.
+
+---
+
+## When to Use / When Not to Use
+
+| Use ISRA when… | Do NOT use ISRA when… |
+|---|---|
+| Conducting a formal ISO 27005 security risk assessment | You need a lightweight threat checklist (no scoring needed) |
+| Assessing a product, system, or service for security risks | You need a real-time collaborative tool (ISRA is single-user, offline) |
+| Migrating an existing InfoPath-based ISRA assessment | You need to export to a structured database or API |
+| Producing a signed-off PDF risk report for stakeholders | |
+
+---
+
+## Workflow Steps (ISO 27005)
+
+The assessment follows this linear progression across the UI tabs:
+
+```
+1. Project Setup (Welcome Tab)
+        ↓
+2. Project Context
+        ↓
+3. Business Assets
+        ↓
+4. Supporting Assets
+        ↓
+5. Vulnerabilities
+        ↓
+6. Risks + Mitigation
+        ↓
+7. Report (PDF export)
+```
+
+### Step 1 — Project Setup (Welcome Tab)
+
+**Purpose:** Identify the project being assessed and record the team conducting the assessment.
+
+**Data captured:**
+- `projectName` — name of the product/system being assessed
+- `projectOrganization` — which team owns the assessment (must be one of the configured organizations)
+- `projectVersion` — version of the product
+- `classification` — document classification label
+- `ISRAtracking` — audit trail: one `ISRAMetaTracking` row per save, recording the date and reviewer
+
+**Validation rule:** `projectOrganization` must be set before saving.
+
+---
+
+### Step 2 — Project Context
+
+**Purpose:** Define the scope of the assessment — what is in-scope, trust boundaries, assumptions.
+
+**Data captured via `ISRAProjectContext`:**
+- Scope description (HTML)
+- Assumptions and constraints
+- Trust boundary descriptions
+- Attachments (base64-encoded supporting documents)
+
+This context is reference material for all subsequent steps; it does not link directly to other entities but is persisted as part of the project.
+
+---
+
+### Step 3 — Business Assets
+
+**Purpose:** Enumerate *what* is valuable — data, services, or capabilities that must be protected.
+
+**Entity:** `BusinessAsset` + embedded `BusinessAssetProperties`
+
+Each Business Asset is assigned:
+- A **type** (e.g. Service, Data, Process)
+- A **description**
+- **Security characteristic scores** for: Confidentiality, Integrity, Availability, Authenticity, Authorization, Non-repudiation
+
+These scores drive the Impact calculation on Risks later.
+
+**Example:**
+
+| Business Asset | Type | Confidentiality | Integrity | Availability |
+|---|---|---|---|---|
+| User Authentication Tokens | Data | High | High | Medium |
+| Payment Processing Service | Service | High | Critical | High |
+
+**Validation rule:** Each Business Asset must have a non-empty name before saving.
+
+---
+
+### Step 4 — Supporting Assets
+
+**Purpose:** Map *where* Business Assets live or flow — the technical components that host them.
+
+**Entity:** `SupportingAsset`
+
+Each Supporting Asset:
+- Has a **type** (e.g. Application, Hardware, Network)
+- Carries a **security level**
+- References one or more `BusinessAsset` IDs via `businessAssetRef[]`
+
+**Example:**
+
+| Supporting Asset | Type | References Business Asset |
+|---|---|---|
+| Auth Service (Node.js API) | Application | User Authentication Tokens |
+| Payment Gateway Integration | Application | Payment Processing Service |
+
+The `supportingAssetsDesc` field on `ISRAProject` accepts an HTML-rich architecture diagram description covering all Supporting Assets.
+
+**Validation rules:** Each Supporting Asset must have a non-empty name and at least one valid (non-duplicate, non-null) Business Asset reference.
+
+---
+
+### Step 5 — Vulnerabilities
+
+**Purpose:** Document specific technical weaknesses that could be exploited on the Supporting Assets.
+
+**Entity:** `Vulnerability`
+
+Each Vulnerability:
+- Is assigned to one or more `SupportingAsset` IDs (`supportingAssetRef`)
+- Has a **family** (e.g. Design, Configuration, Implementation)
+- Is scored with a **CVE vector** (CVSS v2/v3) and `cveScore` (0–10)
+- Receives an `overallScore` and `overallLevel` (Low / Medium / High / Critical)
+- Can carry a tracking ID (e.g. JIRA/GTO ticket) and URL
+
+**Validation rules:** Each Vulnerability must have a non-empty name, non-empty description, at least one valid Supporting Asset reference, and a CVE score between 0 and 10.
+
+---
+
+### Step 6 — Risks + Mitigation
+
+**Purpose:** Define what could go wrong (threat scenarios), evaluate their likelihood and impact, and decide how to treat them.
+
+**Entity:** `Risk` (with nested `RiskLikelihood`, `RiskImpact`, `RiskAttackPath[]`, `RiskMitigation[]`)
+
+Each Risk describes:
+
+**Description sub-section:**
+- `threatAgent` — who attacks (enum)
+- `threatVerb` — what they do (enum: disclose, modify, deny, use, destroy, …)
+- `businessAssetRef` — which Business Asset is targeted
+- `supportingAssetRef` — which Supporting Asset is the attack surface
+- `motivation` — why the attacker acts
+
+**Evaluation sub-section:**
+- One or more `RiskAttackPath` objects — each is an AND-combination of Vulnerabilities on the same Supporting Asset
+- Multiple attack paths are combined with OR logic → `allAttackPathsScore`
+- `riskLikelihood` and `riskImpact` sub-objects provide detailed scoring
+- `inherentRiskScore` = risk score **before** any mitigations
+
+**Mitigation sub-section:**
+- One or more `RiskMitigation` objects, each with: description, cost, `decision` (None / Accepted / Done), and `mitigationsBenefits` (0–1 reduction factor)
+- `mitigationsBenefits` and `mitigationsDoneBenefits` are computed from the individual mitigation decisions
+- `mitigatedRiskScore` = inherent score reduced by mitigations
+
+**Treatment decision:**
+- `riskManagementDecision` — Accept / Mitigate / Avoid / Transfer
+- `residualRiskScore` and `residualRiskLevel` — final classification after treatment
+
+---
+
+### Step 7 — Report
+
+**Purpose:** Export the complete assessment as a signed PDF.
+
+The Report tab renders all tabs' data into a printable view. The user triggers PDF generation via `downloadReport()` in `request-handlers.js`, which uses Electron's `printToPDF` API. The PDF includes:
+- Project metadata header (project name)
+- Classification footer on every page
+- All tabs' data in a formatted layout
+
+---
+
+## Key Entities & Their Roles
+
+| Entity | Produced in Step | Consumed by |
+|---|---|---|
+| `ISRAProject` | Step 1 | All steps (root container) |
+| `ISRAProjectContext` | Step 2 | Report |
+| `BusinessAsset` | Step 3 | Step 4 (`businessAssetRef`), Step 6 (`businessAssetRef`) |
+| `SupportingAsset` | Step 4 | Step 5 (`supportingAssetRef`), Step 6 (`supportingAssetRef`) |
+| `Vulnerability` | Step 5 | Step 6 (`RiskAttackPath.vulnerabilityRef`) |
+| `Risk` | Step 6 | Report |
+
+---
+
+## Risk Scoring & Mitigation
+
+The scoring pipeline for a single Risk:
+
+1. **Attack Path Score** — computed from the vulnerabilities in each `RiskAttackPath` (AND logic within a path, OR logic across paths). `allAttackPathsScore` takes the worst case.
+2. **Inherent Risk Score** — combines `allAttackPathsScore` with `riskLikelihood` and `riskImpact` sub-scores.
+3. **Mitigation Benefits** — for each `RiskMitigation` with `decision = Done`, `mitigationsBenefits` is the fractional reduction (0–1). The combined `mitigationsDoneBenefits` is calculated.
+4. **Mitigated Risk Score** — `inherentRiskScore × (1 - mitigationsDoneBenefits)` (approximate; exact formula is in the handler event code).
+5. **Residual Risk** — after the `riskManagementDecision` is applied, the final `residualRiskScore` and `residualRiskLevel` are set.
+
+---
+
+## Operational Notes
+
+- The workflow is **iterative**, not one-shot. Engineers save intermediate results, and each save increments `iteration` and adds a row to `ISRAtracking`.
+- If you delete a Business Asset that is referenced by a Supporting Asset or Risk, the validation at save time will flag dangling references as errors. Referential integrity is not automatically cascaded.
+- The `isAutomaticRiskName` flag on `Risk` controls whether the `riskName` is auto-computed from `threatAgent + threatVerb + businessAssetRef`; setting it to `false` allows manual naming.
+- All rich-text fields (descriptions, details) accept HTML via TinyMCE. HTML is sanitized before it is persisted — see [Electron Security](electron-security.md).
+
+---
+
+## Assumptions Made
+
+- The ISO 27005 scoring methodology (exact formulas for combining likelihood, impact, and vulnerability scores) is implemented in the Risk handler event code (`api/Risk/handler-event.js`), which was not fully reviewed.
+- `riskManagementDecision` enum values (Accept / Mitigate / Avoid / Transfer) are verified from JSDoc but the exact schema enum was not inspected.
+
+## Open Questions
+
+- What is the precise formula for computing `inherentRiskScore` from likelihood + impact sub-scores?
+- Can a single project have Risks that reference Business Assets from different Supporting Assets simultaneously?
+- Is there a maximum number of RiskAttackPaths or RiskMitigations per Risk?
+
+## Last Reviewed: 2026-06-24

--- a/docs/features/validation-pattern.md
+++ b/docs/features/validation-pattern.md
@@ -1,0 +1,210 @@
+# Validation Pattern
+
+> **Audience:** Newcomers / onboarding developers  
+> **Scope:** How property validation works in the `lib/` model layer (AJV + JSON Schema + class setters), and how the `app/` layer performs per-tab validation before saving.
+
+---
+
+## Purpose & Scope
+
+ISRA uses a **two-level validation strategy**:
+
+1. **Model-level validation** — every property setter on every domain class calls a validator function before accepting a value. Invalid values throw immediately.
+2. **App-level validation** — before saving, the app checks business rules across the entire project graph (e.g. "does every Risk reference a valid, named Supporting Asset?").
+
+This document explains both levels, shows how to add a new validated field, and describes how error messages surface to the user.
+
+---
+
+## AJV Instance & JSON Schema
+
+### The JSON Schema
+
+All valid data shapes are defined in a single file:
+
+```
+lib/src/model/schema/json-schema.js
+```
+
+This file exports:
+- `properties` — the full AJV JSON Schema for the `ISRAProject` structure, including default values for every field.
+- `schemaVersion` — the current schema version integer (maximum supported: `3`).
+
+Every domain class constructor reads its default values from this schema:
+
+```js
+// Example from risk.js constructor
+const riskJsonSchema = require('../../schema/json-schema').properties.Risk.items.properties;
+this.#riskName = riskJsonSchema.riskName.default;
+this.#threatAgent = riskJsonSchema.threatAgent.default;
+```
+
+This means the schema is the **single source of truth** for both validation rules and default values.
+
+### The AJV Instance
+
+A shared, pre-configured AJV instance lives at:
+
+```
+lib/src/model/classes/validation/ajv-instance.js
+```
+
+It is imported by `validateClassProperties` and by `validateJsonSchema`. Using a single shared instance ensures compiled schemas are cached and reused across all validation calls.
+
+### validateJsonSchema
+
+```
+lib/src/api/xml-json/validate-json-schema.js
+```
+
+Called at two points:
+- **On load** — after parsing a `.sra` or `.xml` file, to reject structurally invalid files.
+- **On save** — inside `ISRAProject.toJSON()`, before serializing to JSON.
+
+If validation fails, it throws with a structured error message:
+
+```
+Failed to validate json against schema at: [{"instancePath":"/Risk/0/riskId","message":"must be integer"}]
+```
+
+The `getError()` function in `request-handlers.js` parses this message to extract the affected tab and field name for the user-facing dialog.
+
+---
+
+## Adding a New Validated Field
+
+Follow these steps in order:
+
+**Step 1 — Add the field to `json-schema.js`:**
+
+```js
+// lib/src/model/schema/json-schema.js
+// Under the relevant entity (e.g. properties.Risk.items.properties):
+myNewField: {
+  type: 'string',
+  default: '',
+  pattern: '^[a-zA-Z0-9 ]*$'  // example constraint
+}
+```
+
+**Step 2 — Add a validator function to the class's `validation.js`:**
+
+```js
+// lib/src/model/classes/Risk/validation.js
+const isMyNewField = (value) => typeof value === 'string' && /^[a-zA-Z0-9 ]*$/.test(value);
+module.exports = { ..., isMyNewField };
+```
+
+**Step 3 — Add the private field and setter/getter to the class:**
+
+```js
+// lib/src/model/classes/Risk/risk.js
+const { isMyNewField } = require('./validation');
+
+class Risk {
+  #myNewField;
+
+  constructor() {
+    this.#myNewField = riskJsonSchema.myNewField.default;
+  }
+
+  /** Description of the field
+    * @type {string}
+  */
+  set myNewField(value) {
+    if (isMyNewField(value)) this.#myNewField = value;
+    else throw new Error(`Risk ${this.#riskId}: myNewField is invalid`);
+  }
+
+  get myNewField() {
+    return this.#myNewField;
+  }
+}
+```
+
+**Step 4 — Expose the field in the `.properties` getter:**
+
+```js
+get properties() {
+  return {
+    // ... existing fields
+    myNewField: this.#myNewField,
+  };
+}
+```
+
+**Step 5 — Add/update tests in `lib/test/unit/`** to cover valid and invalid values for the new field.
+
+---
+
+## Per-Tab Validation in the App
+
+Before any save, `request-handlers.js` runs `validateClasses()`, which checks business rules across the entire project graph. This is **separate** from the AJV schema validation — it checks cross-entity referential integrity and required-field completeness.
+
+### Validation checks per tab
+
+| Tab | Checks performed |
+|---|---|
+| **Welcome** | `projectOrganization` must be non-empty |
+| **Business Assets** | Each `businessAssetName` must be non-empty |
+| **Supporting Assets** | Each `supportingAssetName` must be non-empty; each `businessAssetRef` must be non-null, non-duplicate, and reference a named BusinessAsset |
+| **Vulnerabilities** | Each vulnerability must have: non-empty name, non-empty description, ≥1 valid Supporting Asset ref, CVE score 0–10 |
+| **Risks** | Each risk must have: non-empty name, valid threatAgent + threatVerb + businessAssetRef + supportingAssetRef + motivation; attack paths must reference valid vulnerabilities; mitigation costs must be integers if set |
+
+### Helper functions used
+
+```js
+checkBusinessAssetRef(ref)           // BA exists and has a name
+checkBusinessAssetRefArray(refArray) // all BAs in array pass checkBusinessAssetRef
+checkSupportingAssetRef(ref)         // SA exists, has a name, and its BA refs are valid
+checkSupportingAssetRefArray(refArray)
+checkVulnerabilityRef(ref, saRef)    // Vulnerability exists, matches SA, has name+description
+checkRiskAttackPaths(attackPaths, saRef)  // all vulnerability refs in all attack paths are valid
+```
+
+---
+
+## Error Message Format
+
+When `validateClasses()` finds errors, it builds a human-readable message string organized by tab. For example:
+
+```
+⚠️ Business Assets Tab:
+  - 2 assets have empty names. IDs: 1, 3
+
+⚠️ Risks Tab:
+  - 1 risk has invalid description. IDs: 2
+  - 1 risk has invalid attack path evaluation. IDs: 2
+```
+
+This message is shown in a `dialog.showMessageBoxSync` warning that lets the user still save (with errors) or cancel.
+
+For AJV schema errors, the `getError()` helper parses the JSON error and produces:
+
+```
+Invalid data input in Risk Tab,
+`riskId` field: must be integer
+```
+
+---
+
+## Operational Notes
+
+- Validation at the setter level is **synchronous and immediate** — a bad value throws before it is assigned. This prevents the object from ever entering an invalid state.
+- The AJV `validateJsonSchema()` call in `toJSON()` is a final safety net — it catches any state that slipped through setter validation (e.g. from direct property manipulation in tests).
+- If you add a field that is nullable (`integer | null`), your validator function must explicitly accept `null`. Example: `const isMyField = (v) => v === null || Number.isInteger(v)`.
+- There is no client-side form validation in the renderer — all validation is in the main process. The renderer only shows red borders / highlights based on the IPC response.
+
+---
+
+## Assumptions Made
+
+- `validateClassProperties` in `lib/src/model/classes/validation/validate-class-properties.js` is a shared utility for multi-property AJV validation; the exact call signature was not fully reviewed.
+- Enum values for fields like `threatAgent`, `threatVerb`, `vulnerabilityFamily` are defined in `json-schema.js` but not listed here to avoid duplication.
+
+## Open Questions
+
+- Does `validateClassProperties` validate a single property against the schema, or a batch of properties at once?
+- Are there plans to add real-time renderer-side validation (e.g. inline field errors) in the UI?
+
+## Last Reviewed: 2026-06-24

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,0 +1,480 @@
+# ISRA Security Risk Assessment Tool — User Guide
+
+> **Audience:** Security engineers and analysts using the ISRA tool to conduct risk assessments.  
+> **Scope:** Step-by-step usage guide, asset criticality guidelines, and likelihood evaluation guidelines.
+
+---
+
+## Table of Contents
+
+1. [Introduction](#1-introduction)
+2. [Getting Started](#2-getting-started)
+3. [Step-by-Step Workflow](#3-step-by-step-workflow)
+   - [Step 1 – Project Setup](#step-1--project-setup)
+   - [Step 2 – Project Context](#step-2--project-context)
+   - [Step 3 – Business Assets & Criticality](#step-3--business-assets--criticality)
+   - [Step 4 – Supporting Assets](#step-4--supporting-assets)
+   - [Step 5 – Vulnerabilities](#step-5--vulnerabilities)
+   - [Step 6 – Risks & Likelihood Evaluation](#step-6--risks--likelihood-evaluation)
+   - [Step 7 – Report](#step-7--report)
+4. [Asset Criticality Guidelines](#4-asset-criticality-guidelines)
+5. [Likelihood Evaluation Guidelines](#5-likelihood-evaluation-guidelines)
+6. [Risk Treatment Decisions](#6-risk-treatment-decisions)
+7. [Saving & File Formats](#7-saving--file-formats)
+8. [Frequently Asked Questions](#8-frequently-asked-questions)
+
+---
+
+## 1. Introduction
+
+ISRA (Information Security Risk Assessment) is a desktop application that guides security engineers through a structured risk assessment following the **ISO/IEC 27005** standard. It produces a documented, traceable risk register stored as an `.sra` file, and can export a PDF report for stakeholder review.
+
+### Key Concepts
+
+| Term | Definition |
+|---|---|
+| **Business Asset** | What has value from a business perspective (data, services, processes). Also called a *primary asset*. |
+| **Supporting Asset** | The technical component where a Business Asset lives or flows through (e.g., a server, database, network link). |
+| **Vulnerability** | A specific technical weakness on a Supporting Asset that could be exploited. |
+| **Risk** | A threat scenario combining a threat agent, a target, and the vulnerabilities they could exploit. |
+| **Inherent Risk Score** | The risk level before any mitigations are applied. |
+| **Residual Risk Score** | The risk level after mitigations and the management treatment decision are applied. |
+
+---
+
+## 2. Getting Started
+
+### Launching the Application
+
+Download the appropriate binary for your platform from the [releases page](https://github.com/ThalesGroup/security-risk-assessment-tool/releases) and run `sratool` (Linux/macOS) or `SRATool.exe` (Windows).
+
+### Creating a New Assessment
+
+1. Click **New** on the Welcome tab to start a blank assessment.
+2. Enter the project name, organization, and version.
+3. Use **File > Save** (or Ctrl+S) to save your work as an `.sra` file at any time.
+
+### Opening an Existing Assessment
+
+Use **File > Open** to open an `.sra` or `.json` file, or drag and drop the file onto the application window.
+
+### Migrating from InfoPath (Legacy XML)
+
+Use **File > Import XML** to import a legacy InfoPath-based ISRA XML file. The tool will automatically migrate the data to the current format.
+
+---
+
+## 3. Step-by-Step Workflow
+
+The assessment follows a linear progression across the UI tabs. Each step builds on the previous one.
+
+```
+1. Project Setup → 2. Project Context → 3. Business Assets
+        → 4. Supporting Assets → 5. Vulnerabilities
+                → 6. Risks & Mitigation → 7. Report
+```
+
+---
+
+### Step 1 – Project Setup
+
+**Tab:** Welcome
+
+Fill in the basic project metadata:
+
+| Field | Description | Example |
+|---|---|---|
+| Project Name | Name of the product or system being assessed | `PaymentGateway v3` |
+| Organization | Team or division owning the assessment | `FinTech division` |
+| Project Version | Version of the product being assessed | `3.1.0` |
+| Classification | Data classification label for this document | `COMPANY CONFIDENTIAL` |
+
+> **Tip:** The *Organization* dropdown is pre-configured by your tool administrator. If your team is missing, ask an administrator to update `lib/src/config.js`.
+
+---
+
+### Step 2 – Project Context
+
+**Tab:** Project Context
+
+Define the scope of the assessment. This section answers: *What is in scope? What are we NOT assessing?*
+
+- **Scope Description:** Describe the product/system being assessed, its purpose, and the deployment environment.
+- **Assumptions & Constraints:** Document any assumptions (e.g., "assumes TLS is in place between services") and constraints (e.g., "physical security is out of scope").
+- **Trust Boundaries:** Identify where data crosses trust zones — e.g., from a user browser to a backend API, or from an internal service to an external partner.
+- **Attachments:** Upload supporting documents such as architecture diagrams, data flow diagrams, or network topology maps.
+
+> **Tip:** A clear, detailed context section is essential. Reviewers use it to judge whether the scope is appropriate and whether important assets or threats have been omitted.
+
+---
+
+### Step 3 – Business Assets & Criticality
+
+**Tab:** Business Assets
+
+Business Assets are *what* you are protecting. Each represents a unit of information or capability that has business value.
+
+**Adding a Business Asset:**
+1. Click **Add** to create a new asset.
+2. Set the **Name** (e.g., `Customer Payment Data`) and **Type** (Data / Service / Process / Other).
+3. Write a clear **Description** explaining what this asset is and why it is important.
+4. Score each **Security Characteristic** (see [Asset Criticality Guidelines](#4-asset-criticality-guidelines) below).
+
+**Security Characteristics to Score:**
+
+| Characteristic | Description |
+|---|---|
+| **Confidentiality** | Protecting information from unauthorised disclosure |
+| **Integrity** | Ensuring data is accurate and not tampered with |
+| **Availability** | Ensuring the asset is accessible when needed |
+| **Authenticity** | Ensuring the asset's identity or origin can be verified |
+| **Authorization** | Ensuring only permitted entities can access or modify the asset |
+| **Non-repudiation** | Ensuring actions cannot be denied after the fact |
+
+> **See Section 4** for detailed guidance on how to score each characteristic.
+
+---
+
+### Step 4 – Supporting Assets
+
+**Tab:** Supporting Assets
+
+Supporting Assets are the *technical components* that store, process, or transmit your Business Assets. They can have vulnerabilities; Business Assets do not.
+
+**Adding a Supporting Asset:**
+1. Click **Add** to create a new asset.
+2. Set the **Name** (e.g., `Auth Database`) and **Type** (Application / Hardware / Network / Storage / Cryptographic Key / Other).
+3. Write a **Description** identifying where this component sits in the architecture.
+4. **Link to Business Assets:** In the Business Asset reference section, select which Business Assets flow through or are stored in this component.
+
+**Examples:**
+
+| Supporting Asset | Type | Linked Business Asset(s) |
+|---|---|---|
+| `Customer Database (PostgreSQL)` | Storage | Customer Payment Data, Customer PII |
+| `Auth Service API (Node.js)` | Application | Authentication Tokens |
+| `TLS Certificate` | Cryptographic Key | All Business Assets |
+| `Internal Network Segment` | Network | All Business Assets |
+
+> **Tip:** If you are unsure what level of granularity to use, follow the data flow: trace each Business Asset from creation to deletion and add a Supporting Asset for each distinct technical component it passes through.
+
+---
+
+### Step 5 – Vulnerabilities
+
+**Tab:** Vulnerabilities
+
+Vulnerabilities are specific technical weaknesses that could be exploited on a Supporting Asset.
+
+**Adding a Vulnerability:**
+1. Click **Add**.
+2. Set the **Name** (e.g., `SQL Injection in Login Endpoint`) and **Family** (Design / Configuration / Implementation / Operational / Other).
+3. Write a **Description** explaining the weakness.
+4. **Link to Supporting Asset(s):** The vulnerability must be associated with at least one Supporting Asset.
+5. **Score the Vulnerability:**
+   - Enter the **CVSS Vector** (v2 or v3) if a CVE or known scoring exists, or assign a manual score from **0 to 10**.
+   - `0` = No risk, `10` = Critical/maximum risk.
+6. Optionally add a **tracking ID** (e.g., a Jira ticket reference) and a **URL** for further details.
+
+**Scoring Reference:**
+
+| Score Range | Level | Description |
+|---|---|---|
+| 0.0 | None | No impact |
+| 0.1 – 3.9 | Low | Limited exploitability or impact |
+| 4.0 – 6.9 | Medium | Moderate impact, exploitable under specific conditions |
+| 7.0 – 8.9 | High | Significant impact, relatively easy to exploit |
+| 9.0 – 10.0 | Critical | Severe impact, trivial to exploit |
+
+---
+
+### Step 6 – Risks & Likelihood Evaluation
+
+**Tab:** Risks
+
+A Risk defines a complete threat scenario: *who* attacks, *what* they target, *how* they exploit vulnerabilities, and what the *impact* is.
+
+**Adding a Risk:**
+1. Click **Add**.
+2. Complete the **Description** sub-section:
+   - **Threat Agent** — Who is the attacker? (see Likelihood Guidelines, Section 5)
+   - **Threat Verb** — What action do they take? (Disclose / Modify / Deny / Use / Destroy)
+   - **Business Asset** — Which Business Asset is targeted?
+   - **Supporting Asset** — Which Supporting Asset is the attack surface?
+3. Complete the **Evaluation** sub-section:
+   - Build one or more **Attack Paths** by selecting vulnerabilities. Within a path, vulnerabilities are combined with **AND** logic (all must be exploited). Multiple paths are combined with **OR** logic (any path succeeds → risk realised).
+   - Score the **Likelihood** (see [Section 5](#5-likelihood-evaluation-guidelines)).
+4. Complete the **Mitigation** sub-section:
+   - Add security controls as **Mitigations**, each with a description, estimated cost, and expected benefit (% reduction).
+   - Set the `decision` for each mitigation: **None / Accepted / Done**.
+5. Set the **Risk Management Decision**: Accept / Mitigate / Avoid / Transfer.
+
+> **See Section 5** for detailed guidance on likelihood scoring.
+
+---
+
+### Step 7 – Report
+
+**Tab:** Report
+
+The Report tab renders a complete view of all assessment data. When you are satisfied:
+
+1. Click **Download PDF** to export the report.
+2. The PDF includes the project header, classification footer, and all tab data.
+3. Share the PDF with your security review board or project stakeholders.
+
+---
+
+## 4. Asset Criticality Guidelines
+
+The **security characteristic scores** you assign to Business Assets determine how high the *impact* will be if those assets are compromised. Scoring must be consistent across your team.
+
+### Score Scale
+
+| Score Value | Label | Meaning |
+|---|---|---|
+| `0` | None | Loss of this characteristic has no business impact |
+| `1` | Low | Minor inconvenience; easily recoverable; no regulatory implication |
+| `2` | Medium | Noticeable disruption; possible financial or reputational cost |
+| `3` | High | Significant disruption; regulatory notification may be required |
+| `4` | Critical | Severe or irreversible harm; regulatory action, major financial loss, or safety risk |
+
+### Guidance by Characteristic
+
+#### Confidentiality
+Score based on *who should not see this data and what happens if they do*.
+
+| Score | When to apply |
+|---|---|
+| None (0) | Publicly available data — no harm if disclosed |
+| Low (1) | Internal-only data; disclosure is embarrassing but not damaging |
+| Medium (2) | Business-sensitive data; competitive disadvantage if leaked |
+| High (3) | Personal data (GDPR-regulated); financial records; partner agreements |
+| Critical (4) | Passwords, private keys, payment card data (PCI-DSS); health records; government-classified |
+
+#### Integrity
+Score based on *what happens if the data is tampered with or corrupted*.
+
+| Score | When to apply |
+|---|---|
+| None (0) | Data is read-only reference material; tampering has no downstream effect |
+| Low (1) | Errors are easily detected and corrected |
+| Medium (2) | Tampering causes incorrect business decisions or financial discrepancies |
+| High (3) | Corruption causes regulatory or legal exposure, or safety-critical system misbehaviour |
+| Critical (4) | Tampering could cause direct financial fraud, physical harm, or critical system failure |
+
+#### Availability
+Score based on *how much downtime is tolerable*.
+
+| Score | When to apply |
+|---|---|
+| None (0) | Asset is archival or non-operational; outage has no impact |
+| Low (1) | Hours of downtime acceptable; workarounds exist |
+| Medium (2) | Minutes of downtime causes measurable business disruption |
+| High (3) | Near-zero downtime required; SLA penalties if unavailable |
+| Critical (4) | Any outage causes safety risk, irreversible financial loss, or regulatory breach |
+
+#### Authenticity
+Score based on *what happens if the identity or origin of this asset cannot be verified*.
+
+| Score | When to apply |
+|---|---|
+| None (0) | Identity verification is not required for this asset |
+| Low (1) | Impersonation is detectable and correctable |
+| Medium (2) | Impersonation could cause incorrect decisions or financial loss |
+| High (3) | Impersonation has regulatory or contractual implications |
+| Critical (4) | Spoofing could cause direct fraud, safety failure, or unauthorised system access |
+
+#### Authorization
+Score based on *the impact of an unauthorized entity accessing or modifying the asset*.
+
+| Score | When to apply |
+|---|---|
+| None (0) | Asset is public or unrestricted |
+| Low (1) | Unauthorized access is detectable with low impact |
+| Medium (2) | Unauthorized access causes data leakage or limited control hijacking |
+| High (3) | Privilege escalation with significant business impact |
+| Critical (4) | Full system or administrative compromise; financial fraud possible |
+
+#### Non-repudiation
+Score based on *the importance of being able to prove who performed an action*.
+
+| Score | When to apply |
+|---|---|
+| None (0) | Audit trail not required |
+| Low (1) | Useful but not required; disputes can be resolved other ways |
+| Medium (2) | Audit trail is required for internal accountability |
+| High (3) | Required for regulatory compliance or contractual proof |
+| Critical (4) | Required for legal evidence or financial dispute resolution |
+
+### Practical Examples
+
+| Business Asset | Confidentiality | Integrity | Availability | Notes |
+|---|---|---|---|---|
+| Public marketing website content | None | Low | Medium | Publicly visible; tampering is embarrassing; downtime hurts marketing |
+| Customer personal information (GDPR) | High | High | Medium | Subject to GDPR breach notification; integrity errors cause incorrect profiling |
+| Payment card data (PCI-DSS) | Critical | Critical | High | Highest protection required; any breach requires notification and remediation |
+| Internal audit logs | Low | Critical | Low | Logs need not be secret but must not be tampered with |
+| Cryptographic signing keys | Critical | Critical | High | Disclosure or corruption has irreversible impact on all signed assets |
+
+---
+
+## 5. Likelihood Evaluation Guidelines
+
+The **likelihood score** for a risk reflects how probable it is that the threat agent will successfully carry out the attack. It combines two dimensions: **threat agent capability and motivation**, and **supporting asset exposure**.
+
+### Likelihood Score Scale
+
+| Score | Level | Meaning |
+|---|---|---|
+| 0 | None | The attack scenario is theoretically possible but there is no realistic mechanism or motivation |
+| 1 | Low | An advanced, well-resourced attacker with specific knowledge could succeed, but requires significant effort |
+| 2 | Medium | A moderately skilled attacker with access to standard tools could succeed with some effort |
+| 3 | High | A low-skill attacker using publicly available tools and techniques could succeed |
+| 4 | Critical | Attack is trivially easy; requires almost no skill; automated exploitation tools exist |
+
+### Dimension 1 – Threat Agent Profile
+
+First, characterise the threat agent:
+
+| Threat Agent | Typical Skill Level | Typical Motivation | Default Starting Likelihood |
+|---|---|---|---|
+| **Script kiddie / automated scanner** | Low | Opportunistic | High (3) |
+| **External attacker (targeted)** | Medium–High | Financial, espionage | Medium–High (2–3) |
+| **Malicious insider** | Medium (has access) | Financial, revenge, coercion | High (3) |
+| **Nation-state / APT** | Very High | Strategic, espionage | Medium (2) — targeted but stealthy |
+| **Competitor** | Medium–High | Intellectual property theft | Medium (2) |
+| **Accidental insider** | None | Not malicious | Low (1) — probability of triggering unintentionally |
+| **Third-party supplier** | Varies | Varies | Depends on access level |
+
+> **Note:** Nation-state actors are technically very capable but tend to attack only high-value targets with stealth, so the likelihood of *any given system* being targeted by an APT is often Medium even though the attacker's skill is Critical.
+
+### Dimension 2 – Attack Surface & Exposure
+
+Adjust the likelihood based on how exposed the Supporting Asset is:
+
+| Exposure Factor | Adjustment |
+|---|---|
+| Asset is internet-facing with no authentication | +1 |
+| Asset is internet-facing with authentication | 0 |
+| Asset is internal-network accessible (authenticated) | -1 |
+| Asset is internal-network, requires physical access | -2 |
+| Asset is air-gapped or offline | -2 (minimum 0) |
+| Exploit requires a known public CVE with PoC | +1 |
+| Exploit requires proprietary knowledge or reverse engineering | -1 |
+| Attack requires social engineering (phishing, vishing) | 0 (human factor — do not reduce) |
+
+### Dimension 3 – Existing Controls
+
+If mitigating controls already exist (before this assessment's proposed mitigations), you may further reduce likelihood:
+
+| Existing Control | Adjustment |
+|---|---|
+| WAF / IDS / IPS actively monitoring | -1 |
+| MFA enforced on all access paths | -1 |
+| Network segmentation isolates the asset | -1 |
+| Security monitoring with alert response SLA | -1 (max total reduction from controls: -2) |
+
+### Putting It Together — Worked Examples
+
+**Example 1: SQL Injection on a public-facing login page**
+
+| Factor | Value |
+|---|---|
+| Threat agent | External attacker (automated scanner) → Starting: 3 |
+| Asset exposure | Internet-facing, no WAF → +1 |
+| CVE / PoC available? | Yes (OWASP Top 10) → +1 |
+| Existing controls | None |
+| **Final Likelihood** | **min(4, 3+1+1) = Critical (4)** |
+
+---
+
+**Example 2: Privilege escalation on an internal admin console**
+
+| Factor | Value |
+|---|---|
+| Threat agent | Malicious insider → Starting: 3 |
+| Asset exposure | Internal network only → -1 |
+| Exploit requires proprietary knowledge? | No → 0 |
+| Existing controls | MFA enforced → -1 |
+| **Final Likelihood** | **3 - 1 - 1 = Medium (1→ Low–Medium: use 1)** |
+
+---
+
+**Example 3: Private key extraction from an HSM**
+
+| Factor | Value |
+|---|---|
+| Threat agent | Nation-state APT → Starting: 2 |
+| Asset exposure | Air-gapped HSM → -2 |
+| Physical access required | Already accounted for above |
+| Existing controls | Physical security monitoring → -1 |
+| **Final Likelihood** | **max(0, 2 - 2 - 1) = None (0)** |
+
+---
+
+### Documenting Likelihood Decisions
+
+Always document your reasoning in the **Motivation** and **Risk Description** fields so that reviewers can validate and challenge your scores. A likelihood score without justification is not auditable.
+
+---
+
+## 6. Risk Treatment Decisions
+
+Once a risk is scored, you must choose how to treat it:
+
+| Decision | When to Use | Example |
+|---|---|---|
+| **Mitigate** | When a cost-effective control can reduce the risk to an acceptable level | Add input validation to eliminate SQL injection |
+| **Accept** | When the residual risk is within tolerance and mitigation cost exceeds benefit | Accept a low-likelihood, low-impact risk with no cost-effective fix |
+| **Avoid** | When the activity causing the risk can be stopped entirely | Remove a feature that processes sensitive data unnecessarily |
+| **Transfer** | When the risk can be shifted to another party (insurance, outsourcing, SLA) | Shift liability for payment fraud to a certified payment processor |
+
+> **Tip:** "Accept" must always be a conscious, documented decision — not a default. Document *who* accepted the risk and *why* in the risk description.
+
+---
+
+## 7. Saving & File Formats
+
+### File Formats
+
+| Extension | Format | When Used |
+|---|---|---|
+| `.sra` | JSON (primary format) | All new assessments |
+| `.json` | JSON (legacy) | Imported from older versions |
+| `.xml` | InfoPath XML (legacy) | Import only, cannot be saved back to XML |
+
+### Save Behaviour
+
+- Every **save** increments the iteration counter and adds a row to the audit trail (`ISRAtracking`) with the current date.
+- The tool validates all fields on save. If required fields are missing or referential integrity is broken, a list of validation errors is displayed. **The file is still saved** but the errors should be resolved before the final review.
+
+### Backup Recommendation
+
+The `.sra` file is the single source of truth. Keep it under version control (e.g., Git) or in a shared drive with versioning enabled.
+
+---
+
+## 8. Frequently Asked Questions
+
+**Q: I deleted a Supporting Asset but now see validation errors about missing references.**  
+A: When you delete a Supporting Asset, any Vulnerabilities or Risks that referenced it now have dangling references. Navigate to the Vulnerabilities and Risks tabs and update or remove the invalid references before saving.
+
+**Q: Can multiple engineers work on the same `.sra` file simultaneously?**  
+A: No. ISRA is a single-user, offline desktop application. Coordinate with your team to avoid overwriting each other's changes. Consider using Git to manage concurrent edits.
+
+**Q: The risk score seems too low / too high. How is it calculated?**  
+A: The risk score combines the attack path vulnerability scores, the likelihood score, and the business asset impact scores. Review the Business Asset security characteristic scores (Section 4) and the likelihood score (Section 5) to ensure they are calibrated correctly.
+
+**Q: When should I use AND vs. OR in an attack path?**  
+A: Use **AND** when an attacker must exploit *all* vulnerabilities in a path to succeed (e.g., must bypass authentication AND exploit a code injection). Use **OR** (multiple attack paths) when there are *alternative* routes to achieve the same threat outcome.
+
+**Q: How do I export a PDF report?**  
+A: Navigate to the **Report** tab and click **Download PDF**. Ensure all tabs have been completed and saved before generating the final report.
+
+**Q: The tool shows a blank page on macOS.**  
+A: This is a known issue ([#299](https://github.com/ThalesGroup/security-risk-assessment-tool/issues/299)) affecting macOS x64 binaries. Check the releases page for a fix or build from source.
+
+---
+
+*This guide covers ISRA version 1.2.0 and later. For developer and architecture documentation, see the [docs/](.) folder.*


### PR DESCRIPTION
The documentation work for issue #327 is complete. Here's a summary of what was done:

### ✅ What was created

__`docs/user-guide.md`__ (480 lines) — A comprehensive end-user guide covering exactly what issue #327 requested:

1. __Step-by-step workflow guide__ — All 7 assessment phases from Project Setup through to PDF Report export
2. __Asset criticality guidelines__ — Scoring tables for all 6 security characteristics (Confidentiality, Integrity, Availability, Authenticity, Authorization, Non-repudiation) with a 0–4 scale, "when to apply" criteria, and practical examples (GDPR data, PCI-DSS, audit logs, crypto keys)
3. __Likelihood evaluation guidelines__ — A 3-dimensional scoring approach: threat agent profile, attack surface exposure adjustments, and existing controls adjustments — with three worked examples (SQL injection, privilege escalation, HSM key extraction)
4. __Risk treatment decisions, file format reference, and FAQ__
